### PR TITLE
Set sonar.delphi.installationPath when initializing SonarDelphi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* DelphiLint now passes SonarDelphi the correct Delphi installation path and compiler version when running in Delphi 12.
+
 ## [1.0.0] - 2024-03-19
 
 ### Added

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/analysis/EngineStartupConfiguration.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/analysis/EngineStartupConfiguration.java
@@ -38,7 +38,7 @@ public class EngineStartupConfiguration {
 
   public Map<String, String> getBaseProperties() {
     return Map.of(
-        "sonar.delphi.bds.path", bdsPath,
-        "sonar.delphi.compiler.version", compilerVersion);
+        "sonar.delphi.installationPath", bdsPath,
+        "sonar.delphi.compilerVersion", compilerVersion);
   }
 }


### PR DESCRIPTION
Fixes #10 by using the correct setting name for the SonarDelphi property containing Delphi installation.

DelphiLint currently incorrectly passes the Delphi installation through to SonarDelphi using the `sonar.delphi.bds.path` setting, which was replaced by `sonar.delphi.installationPath` in [SonarDelphi 1.0.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.0.0). As a result, SonarDelphi uses the default Delphi 11 installation path in all cases, which causes errors when Delphi 11 is not installed.
