### PR TITLE
Use JVM in server mode and make JVM command line options configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* The arguments passed to the server JVM can now be customized via the `Server.JvmOptions` setting.
+
+### Changed
+
+* The server JVM is now initialized in `-server` mode.
+
 ### Fixed
 
 * DelphiLint now passes SonarDelphi the correct Delphi installation path and compiler version when running in Delphi 12.

--- a/client/source/DelphiLint.Server.pas
+++ b/client/source/DelphiLint.Server.pas
@@ -621,7 +621,8 @@ function TLintServer.StartExtServer(
     CreationFlags: Cardinal;
     ErrorCode: Integer;
   begin
-    CommandLine := Format(' -Djava.net.useSystemProxies=true -jar "%s" "%s"', [Jar, PortFile]);
+    CommandLine := Format(' %s -jar "%s" "%s"', [LintContext.Settings.ServerJvmOptions, Jar, PortFile]);
+    Log.Info('Starting external server with command: %s%s', [JavaExe, CommandLine]);
 
     ZeroMemory(@StartupInfo, SizeOf(TStartupInfo));
     StartupInfo.cb := SizeOf(TStartupInfo);

--- a/client/source/DelphiLint.Settings.pas
+++ b/client/source/DelphiLint.Settings.pas
@@ -65,6 +65,7 @@ type
     property ClientSaveBeforeAnalysis: Boolean index 5 read GetValueBool write SetValueBool;
     // SonarHostTokens index 6
     property ServerSonarDelphiVersionOverride: string index 7 read GetValueStr write SetValueStr;
+    property ServerJvmOptions: string index 8 read GetValueStr write SetValueStr;
 
     property ServerJar: string index 0 read GetServerJar;
     property JavaExe: string index 1 read GetJavaExe;
@@ -126,7 +127,9 @@ begin
     // 6
     TStringPropField.Create('SonarHost', 'Tokens', True),
     // 7
-    TStringPropField.Create('Server', 'SonarDelphiVersionOverride', '')
+    TStringPropField.Create('Server', 'SonarDelphiVersionOverride', ''),
+    // 8
+    TStringPropField.Create('Server', 'JvmOptions', '-server -Djava.net.useSystemProxies=true')
   ];
 end;
 

--- a/client/test/DelphiLintTest.Settings.pas
+++ b/client/test/DelphiLintTest.Settings.pas
@@ -59,6 +59,12 @@ type
     [Test]
     procedure TestSonarHostTokens;
     [Test]
+    procedure TestServerJvmOptions;
+    [Test]
+    procedure TestDefaultServerJvmOptionsUseSystemProxies;
+    [Test]
+    procedure TestDefaultServerJvmOptionsUseSystemVm;
+    [Test]
     procedure TestSaveAndLoad;
   end;
 
@@ -68,6 +74,7 @@ uses
     System.IOUtils
   , System.SysUtils
   , System.IniFiles
+  , System.StrUtils
   , Winapi.Windows
   , DelphiLint.Version
   ;
@@ -258,6 +265,36 @@ begin
   FSettings.ServerJarOverride := 'efgh';
   FSettings.Save;
   Assert.AreEqual('efgh', GetSetting(CCategory, CName));
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TSettingsTest.TestServerJvmOptions;
+const
+  CCategory = 'Server';
+  CName = 'JvmOptions';
+begin
+  SetSetting(CCategory, CName, 'abcdefg');
+  FSettings.Load;
+  Assert.AreEqual(FSettings.ServerJvmOptions, 'abcdefg');
+
+  FSettings.ServerJvmOptions := 'efgh';
+  FSettings.Save;
+  Assert.AreEqual('efgh', GetSetting(CCategory, CName));
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TSettingsTest.TestDefaultServerJvmOptionsUseSystemProxies;
+begin
+  Assert.Contains<string>(SplitString(FSettings.ServerJvmOptions, ' '), '-Djava.net.useSystemProxies=true');
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TSettingsTest.TestDefaultServerJvmOptionsUseSystemVm;
+begin
+  Assert.Contains<string>(SplitString(FSettings.ServerJvmOptions, ' '), '-server');
 end;
 
 //______________________________________________________________________________________________________________________


### PR DESCRIPTION
An out-of-memory exception was reported on integrated-application-development/sonar-delphi#207, seemingly due to the JVM defaulting to a client VM instead of a server VM on a 32-bit JRE installation.

This PR does two things:

- Fixes this issue by passing the JVM the `-server` argument
- Adds functionality to customize the arguments passed to the JVM when it is initialized