### PR TITLE
Center issue position on screen when using double click navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Double clicking an issue in the issue view now centers the relevant line in the editor.
+
 ## [1.0.1] - 2024-03-20
 
 ### Added

--- a/client/source/DelphiLint.IDEContext.pas
+++ b/client/source/DelphiLint.IDEContext.pas
@@ -569,9 +569,14 @@ begin
 end;
 
 procedure TToolsApiEditView.GoToPosition(const Line: Integer; const Column: Integer);
+var
+  ScrollLine: Integer;
 begin
   FRaw.Buffer.EditPosition.GotoLine(Line);
-  FRaw.Buffer.EditPosition.Column;
+  FRaw.Buffer.EditPosition.MoveRelative(0, Column);
+
+  ScrollLine := Line - (FRaw.ViewSize.Height div 2);
+  FRaw.SetTopLeft(ScrollLine, 0);
 end;
 
 procedure TToolsApiEditView.Paint;


### PR DESCRIPTION
Double clicking an issue in the issue view currently moves the cursor to the line the issue is on. While this is better than nothing, it can sometimes be difficult to notice as the IDE scrolls the bare minimum amount needed to view the line - meaning that it's usually the top or bottom line in the editor.

This PR changes this behaviour to:

1. Move the cursor to the column, as well as the line (this was broken due to a typo), and
2. Scroll upwards so the line is vertically centered in the editor.