### PR TITLE
Fix high CPU usage when waiting for server to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Double clicking an issue in the issue view now centers the relevant line in the editor.
 
+### Fixed
+
+* Idling before the DelphiLint server has been started no longer causes noticeable CPU usage.
+
 ## [1.0.1] - 2024-03-20
 
 ### Added


### PR DESCRIPTION
The DelphiLint client spawns the server process lazily, but the server communication thread is started on startup. At present, the thread spin-waits until the process is started, causing unnecessary CPU usage before an analysis is run for the first time (idle CPU usage up to 8-10% on my PC).

This PR modifies the thread logic to instead wait for a `TEvent` that is triggered when the server process is initialized. This fixes the issue (idle CPU usage back down to 0-0.5% on my PC). 

Fixes #20. 