### PR TITLE
Add support for clearing file issues in VSCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* VS Code companion: Re-analyzing a file that previously had issues will now clear the old issues when there are no new
+  issues reported
+
 ## [1.0.2] - 2024-04-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* VS Code companion: Clear Issues For This File command, which removes any outstanding issues on the current file.
+
 ### Fixed
 
 * VS Code companion: Re-analyzing a file that previously had issues will now clear the old issues when there are no new

--- a/companion/delphilint-vscode/package.json
+++ b/companion/delphilint-vscode/package.json
@@ -42,6 +42,10 @@
       {
         "command": "delphilint-vscode.analyzeAllOpenFiles",
         "title": "DelphiLint: Analyze All Open Files"
+      },
+      {
+        "command": "delphilint-vscode.clearThisFile",
+        "title": "DelphiLint: Clear Issues For This File"
       }
     ],
     "configuration": {

--- a/companion/delphilint-vscode/src/command.ts
+++ b/companion/delphilint-vscode/src/command.ts
@@ -105,6 +105,11 @@ async function doAnalyze(
   statusUpdate(analyzingMsg);
 
   const issues = await server.analyze(msg);
+
+  for (const filePath of sourceFiles) {
+    issueCollection.set(vscode.Uri.file(filePath), undefined);
+  }
+
   display.showIssues(issues, issueCollection);
 
   const issueWord = issues.length === 1 ? "issue" : "issues";

--- a/companion/delphilint-vscode/src/command.ts
+++ b/companion/delphilint-vscode/src/command.ts
@@ -293,3 +293,12 @@ export async function chooseActiveProject() {
     resource.setActiveProject(activeProject);
   });
 }
+
+export async function clearThisFile(
+  issueCollection: vscode.DiagnosticCollection
+) {
+  const activeTextEditor = vscode.window.activeTextEditor;
+  if (activeTextEditor) {
+    issueCollection.set(activeTextEditor.document.uri, undefined);
+  }
+}

--- a/companion/delphilint-vscode/src/extension.ts
+++ b/companion/delphilint-vscode/src/extension.ts
@@ -21,6 +21,7 @@ import {
   analyzeAllOpenFiles,
   analyzeThisFile,
   chooseActiveProject,
+  clearThisFile,
 } from "./command";
 import { getStatusItem } from "./display";
 import * as settings from "./settings";
@@ -78,6 +79,11 @@ export function activate(context: vscode.ExtensionContext) {
     async () => analyzeAllOpenFiles(getServer, lintIssueCollection)
   );
   context.subscriptions.push(analyzeAllOpenFilesCommand);
+
+  const clearThisFileCommand = vscode.commands.registerCommand(
+    "delphilint-vscode.clearThisFile",
+    () => clearThisFile(lintIssueCollection)
+  );
 
   const chooseActiveProjectCommand = vscode.commands.registerCommand(
     "delphilint-vscode.chooseActiveProject",


### PR DESCRIPTION
This PR adds a new `Clear All Issues In This File` command to the VSCode companion, which does what it says on the box.
It also fixes a bug that would cause files that had been previously analyzed to not have their issues cleared if the second analysis returned zero issues.