### PR TITLE
Implement quick fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Clear Active File menu item, which clears all issues from the active file.
 * VS Code companion: Clear Issues For This File command, which removes any outstanding issues on the current file.
+* Support for "quick fixes" in the IDE - suggested fixes that can be applied automatically.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Changes in issue validity are now immediately reflected across the UI.
 * The issue view has been redesigned for improved performance and utility.
+* The default SonarDelphi version is now [1.5.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.5.0).
 
 ### Fixed
 

--- a/client/source/DelphiLint.Context.pas
+++ b/client/source/DelphiLint.Context.pas
@@ -67,7 +67,7 @@ type
     function GetOnAnalysisStateChanged: TEventNotifier<TAnalysisStateChangeContext>;
     function GetCurrentAnalysis: TCurrentAnalysis;
     function GetInAnalysis: Boolean;
-    function GetIssues(FileName: string; Line: Integer = -1): TArray<ILiveIssue>;
+    function GetIssues(FileName: string; Line: Integer = -1; Column: Integer = -1): TArray<ILiveIssue>;
     function GetRule(RuleKey: string; AllowRefresh: Boolean = True): TRule;
 
     procedure UpdateIssueLine(FilePath: string; OriginalLine: Integer; NewLine: Integer);
@@ -103,10 +103,22 @@ type
     function AddNotifier(Notifier: IIDEViewHandler): Integer;
     procedure RemoveNotifier(Index: Integer);
     function GetLeftColumn: Integer;
+    procedure ReplaceText(
+      Replacement: string;
+      StartLine: Integer;
+      StartColumn: Integer;
+      EndLine: Integer;
+      EndColumn: Integer
+    );
+    function GetColumn: Integer;
+    function GetRow: Integer;
+    function GetContextMenu: TPopupMenu;
     function Raw: IInterface; // IOTAEditView
 
     property FileName: string read GetFileName;
     property LeftColumn: Integer read GetLeftColumn;
+    property Column: Integer read GetColumn;
+    property Row: Integer read GetRow;
   end;
 
   IIDESourceEditor = interface
@@ -236,6 +248,10 @@ type
     // From IOTAEditorServices
     function AddEditorNotifier(Notifier: IIDEEditorHandler): Integer;
     procedure RemoveEditorNotifier(const Index: Integer);
+    function GetTopView: IIDEEditView;
+
+    // From INTAEditorServices
+    function GetTopEditWindow: TCustomForm;
 
     // From INTAEnvironmentOptionsServices
     procedure RegisterAddInOptions(const Options: TAddInOptionsBase);

--- a/client/source/DelphiLint.IssueActions.pas
+++ b/client/source/DelphiLint.IssueActions.pas
@@ -26,6 +26,9 @@ uses
   ;
 
 type
+
+//______________________________________________________________________________________________________________________
+
   TIssueMenuItemFactory = class(TObject)
   private
     FIssue: ILiveIssue;
@@ -35,7 +38,10 @@ type
     destructor Destroy; override;
 
     function HideIssue(Owner: TComponent): TMenuItem;
+    function ApplyQuickFix(Owner: TComponent): TMenuItem;
   end;
+
+//______________________________________________________________________________________________________________________
 
   TIssueLinkedMenuItem = class abstract(TMenuItem)
   private
@@ -48,12 +54,41 @@ type
     property LinkedIssue: ILiveIssue read FIssue;
   end;
 
+//______________________________________________________________________________________________________________________
+
   TUntetherMenuItem = class(TIssueLinkedMenuItem)
   protected
     procedure DoOnClick(Sender: TObject); override;
   end;
 
+//______________________________________________________________________________________________________________________
+
+  TQuickFixMenuItem = class(TIssueLinkedMenuItem)
+  private
+    FIndex: Integer;
+
+    procedure CalculateReplacementMetrics(
+      TextEdit: TLiveTextEdit;
+      out AddedLines: Integer;
+      out AddedColumns: Integer
+    );
+    procedure OffsetTextEdits(QuickFix: TLiveQuickFix; EditIndex: Integer);
+    function GetQuickFix: TLiveQuickFix;
+  protected
+    procedure DoOnClick(Sender: TObject); override;
+  public
+    constructor CreateLinked(AOwner: TComponent; Issue: ILiveIssue; Index: Integer);
+    property QuickFix: TLiveQuickFix read GetQuickFix;
+  end;
+
+//______________________________________________________________________________________________________________________
+
 implementation
+
+uses
+    System.SysUtils
+  , DelphiLint.Context
+  ;
 
 //______________________________________________________________________________________________________________________
 
@@ -76,8 +111,50 @@ end;
 function TIssueMenuItemFactory.HideIssue(Owner: TComponent): TMenuItem;
 begin
   Result := TUntetherMenuItem.CreateLinked(Owner, FIssue);
-  Result.Caption := 'Hide';
+  Result.Name := 'HideIssue';
+  Result.Caption := 'Hide Issue';
   Result.Enabled := FIssue.IsTethered;
+end;
+
+//______________________________________________________________________________________________________________________
+
+function TIssueMenuItemFactory.ApplyQuickFix(Owner: TComponent): TMenuItem;
+
+  function QuickFixItem(Index: Integer; IndexInName: Boolean): TQuickFixMenuItem;
+  begin
+    Result := TQuickFixMenuItem.CreateLinked(Owner, FIssue, Index);
+    Result.Name := Format('ApplyQuickFix_%d', [Index]);
+    Result.Enabled := Result.QuickFix.Tethered;
+
+    if IndexInName then begin
+      Result.Caption := Format('&%d: %s', [Index + 1, Result.QuickFix.Message]);
+    end
+    else begin
+      Result.Caption := Format('&Quick Fix: %s', [Result.QuickFix.Message]);
+    end;
+  end;
+
+var
+  I: Integer;
+  FixCount: Integer;
+begin
+  FixCount := FIssue.QuickFixes.Count;
+
+  if FixCount = 0 then begin
+    Result := nil;
+  end
+  else if FixCount = 1 then begin
+    Result := QuickFixItem(0, False);
+  end
+  else begin
+    Result := TMenuItem.Create(Owner);
+    Result.Name := 'DelphiLintApplyQuickFixGroup';
+    Result.Caption := Format('&Quick Fix (%d available)', [FixCount]);
+
+    for I := 0 to FixCount - 1 do begin
+      Result.Add(QuickFixItem(I, True));
+    end;
+  end;
 end;
 
 //______________________________________________________________________________________________________________________
@@ -98,5 +175,140 @@ begin
 end;
 
 //______________________________________________________________________________________________________________________
+
+constructor TQuickFixMenuItem.CreateLinked(AOwner: TComponent; Issue: ILiveIssue; Index: Integer);
+begin
+  inherited CreateLinked(AOwner, Issue);
+  FIndex := Index;
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TQuickFixMenuItem.DoOnClick(Sender: TObject);
+var
+  QuickFix: TLiveQuickFix;
+  TextEdit: TLiveTextEdit;
+  View: IIDEEditView;
+  I: Integer;
+begin
+  if FIssue.QuickFixes.Count < FIndex then begin
+    Log.Warn('Quick fix menu item wanted nonexistent quick fix at index %d', [FIndex]);
+    Exit;
+  end;
+
+  QuickFix := FIssue.QuickFixes[FIndex];
+  View := LintContext.IDEServices.GetTopView;
+
+  if not QuickFix.Tethered then begin
+    Log.Warn('Attempted to apply an untethered quick fix');
+    Exit;
+  end
+  else if not Assigned(View) then begin
+    Log.Warn('No top view found when applying quick fix');
+    Exit;
+  end;
+
+  for I := 0 to QuickFix.TextEdits.Count - 1 do begin
+    TextEdit := QuickFix.TextEdits[I];
+
+    View.ReplaceText(
+      TextEdit.Replacement,
+      QuickFix.Issue.StartLine + TextEdit.RelativeStartLine,
+      TextEdit.StartLineOffset,
+      QuickFix.Issue.StartLine + TextEdit.RelativeEndLine,
+      TextEdit.EndLineOffset
+    );
+
+    OffsetTextEdits(QuickFix, I);
+  end;
+
+  QuickFix.Untether;
+  View.Paint;
+end;
+
+//______________________________________________________________________________________________________________________
+
+function TQuickFixMenuItem.GetQuickFix: TLiveQuickFix;
+begin
+  Result := nil;
+  if (FIndex >= 0) and (FIndex < FIssue.QuickFixes.Count) then begin
+    Result := FIssue.QuickFixes[FIndex];
+  end;
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TQuickFixMenuItem.CalculateReplacementMetrics(
+  TextEdit: TLiveTextEdit;
+  out AddedLines: Integer;
+  out AddedColumns: Integer
+);
+var
+  RangeLength: Integer;
+  RangeHeight: Integer;
+  ReplacementLastLineLength: Integer;
+  Lines: TStringList;
+begin
+  if TextEdit.RelativeStartLine = TextEdit.RelativeEndLine then begin
+    RangeHeight := 1;
+    RangeLength := TextEdit.EndLineOffset - TextEdit.StartLineOffset;
+  end
+  else begin
+    RangeHeight := TextEdit.RelativeEndLine - TextEdit.RelativeStartLine;
+    RangeLength := TextEdit.EndLineOffset;
+  end;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := TextEdit.Replacement;
+
+    if Lines.Count <> 0 then begin
+      ReplacementLastLineLength := Length(Lines[Lines.Count - 1]);
+      AddedColumns := ReplacementLastLineLength - RangeLength;
+      AddedLines := Lines.Count - RangeHeight;
+    end
+    else begin
+      AddedColumns := -RangeLength;
+      AddedLines := 0;
+    end;
+  finally
+    FreeAndNil(Lines);
+  end;
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TQuickFixMenuItem.OffsetTextEdits(QuickFix: TLiveQuickFix; EditIndex: Integer);
+var
+  AppliedEdit: TLiveTextEdit;
+  I: Integer;
+  LinesAdded: Integer;
+  ColumnsAdded: Integer;
+  SuccessorEdit: TLiveTextEdit;
+begin
+  AppliedEdit := QuickFix.TextEdits[EditIndex];
+  CalculateReplacementMetrics(AppliedEdit, LinesAdded, ColumnsAdded);
+
+  for I := EditIndex + 1 to QuickFix.TextEdits.Count - 1 do begin
+    SuccessorEdit := QuickFix.TextEdits[I];
+
+    if SuccessorEdit.RelativeStartLine >= AppliedEdit.RelativeEndLine then begin
+      if (SuccessorEdit.RelativeStartLine = AppliedEdit.RelativeEndLine)
+        and(SuccessorEdit.StartLineOffset > AppliedEdit.EndLineOffset)
+      then begin
+        SuccessorEdit.StartLineOffset := SuccessorEdit.StartLineOffset + ColumnsAdded;
+      end;
+
+      if (SuccessorEdit.RelativeEndLine = AppliedEdit.RelativeEndLine)
+        and (SuccessorEdit.EndLineOffset > AppliedEdit.EndLineOffset)
+      then begin
+        SuccessorEdit.EndLineOffset := SuccessorEdit.EndLineOffset + ColumnsAdded;
+      end;
+
+      SuccessorEdit.RelativeStartLine := SuccessorEdit.RelativeStartLine + LinesAdded;
+      SuccessorEdit.RelativeEndLine := SuccessorEdit.RelativeEndLine + LinesAdded;
+    end;
+  end;
+end;
 
 end.

--- a/client/source/DelphiLint.PopupHook.pas
+++ b/client/source/DelphiLint.PopupHook.pas
@@ -1,0 +1,159 @@
+{
+DelphiLint Client
+Copyright (C) 2024 Integrated Application Development
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+}
+unit DelphiLint.PopupHook;
+
+interface
+
+uses
+    System.Classes
+  , Vcl.Menus
+  , DelphiLint.Events
+  ;
+
+type
+  TEditorPopupMenuHook = class(TComponent)
+  private
+    FMenu: TPopupMenu;
+    FBaseOnPopup: TNotifyEvent;
+    FOnFreed: TEventNotifier<TEditorPopupMenuHook>;
+
+    procedure PopulatePopup(Sender: TObject);
+    procedure ClearTaggedItems;
+    procedure TagItem(Item: TMenuItem);
+  public
+    constructor Create(Owner: TComponent); override;
+    destructor Destroy; override;
+
+    property OnFreed: TEventNotifier<TEditorPopupMenuHook> read FOnFreed;
+  end;
+
+implementation
+
+uses
+    System.SysUtils
+  , DelphiLint.Context
+  , DelphiLint.LiveData
+  , DelphiLint.IssueActions
+  ;
+
+const
+  CDelphiLintMenuItemTag = 856248;
+
+//______________________________________________________________________________________________________________________
+
+procedure TEditorPopupMenuHook.ClearTaggedItems;
+var
+  I: Integer;
+begin
+  for I := FMenu.Items.Count - 1 downto 0 do begin
+    if FMenu.Items[I].Tag = CDelphiLintMenuItemTag then begin
+      FMenu.Items[I].Free;
+    end;
+  end;
+end;
+
+//______________________________________________________________________________________________________________________
+
+constructor TEditorPopupMenuHook.Create(Owner: TComponent);
+begin
+  inherited;
+
+  Assert(Owner is TPopupMenu, 'Popup menu hook owner is not a TPopupMenu');
+  FMenu := TPopupMenu(Owner);
+
+  FBaseOnPopup := FMenu.OnPopup;
+  FMenu.OnPopup := PopulatePopup;
+
+  FOnFreed := TEventNotifier<TEditorPopupMenuHook>.Create;
+end;
+
+//______________________________________________________________________________________________________________________
+
+destructor TEditorPopupMenuHook.Destroy;
+begin
+  FOnFreed.Notify(Self);
+  FreeAndNil(FOnFreed);
+  ClearTaggedItems;
+  FMenu.OnPopup := FBaseOnPopup;
+  inherited;
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TEditorPopupMenuHook.PopulatePopup(Sender: TObject);
+
+  function Separator(Owner: TComponent): TMenuItem;
+  begin
+    Result := TMenuItem.Create(Owner);
+    Result.Name := 'DelphiLintSeparator';
+    Result.Caption := '-';
+    TagItem(Result);
+  end;
+
+var
+  TopView: IIDEEditView;
+  Issues: TArray<ILiveIssue>;
+  Issue: ILiveIssue;
+  MenuItemFactory: TIssueMenuItemFactory;
+  MenuItem: TMenuItem;
+  SeparatorAdded: Boolean;
+begin
+  if Assigned(FBaseOnPopup) then begin
+    FBaseOnPopup(Sender);
+  end;
+
+  ClearTaggedItems;
+
+  if not ContextValid then begin
+    Exit;
+  end;
+
+  SeparatorAdded := False;
+  TopView := LintContext.IDEServices.GetTopView;
+  if Assigned(TopView) then begin
+    Issues := Analyzer.GetIssues(TopView.FileName, TopView.Row, TopView.Column);
+
+    for Issue in Issues do begin
+      if not SeparatorAdded then begin
+        FMenu.Items.Add(Separator(FMenu));
+        SeparatorAdded := True;
+      end;
+
+      MenuItemFactory := TIssueMenuItemFactory.Create(Issue);
+      try
+        // Apply quick fix
+        MenuItem := MenuItemFactory.ApplyQuickFix(FMenu);
+        if Assigned(MenuItem) then begin
+          TagItem(MenuItem);
+          FMenu.Items.Add(MenuItem);
+        end;
+      finally
+        FreeAndNil(MenuItemFactory);
+      end;
+    end;
+  end;
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TEditorPopupMenuHook.TagItem(Item: TMenuItem);
+begin
+  Item.Tag := CDelphiLintMenuItemTag;
+end;
+
+end.

--- a/client/source/DelphiLint.Settings.pas
+++ b/client/source/DelphiLint.Settings.pas
@@ -169,7 +169,7 @@ end;
 
 function TLintSettings.GetDefaultSonarDelphiVersion: string;
 begin
-  Result := '1.4.0';
+  Result := '1.5.0';
 end;
 
 //______________________________________________________________________________________________________________________

--- a/client/source/DelphiLint.ToolFrame.pas
+++ b/client/source/DelphiLint.ToolFrame.pas
@@ -222,6 +222,7 @@ function TLintToolFrame.CreateIssuePopup(Index: Integer): TPopupMenu;
 var
   Issue: ILiveIssue;
   MenuItemFactory: TIssueMenuItemFactory;
+  Item: TMenuItem;
   I: Integer;
 begin
   if (Index < 0) or (Index >= FIssues.Count) then begin
@@ -240,6 +241,11 @@ begin
   try
     Result.Items.Add(DummyMenuItem(Result));
     Result.Items.Add(MenuItemFactory.HideIssue(Result));
+
+    Item := MenuItemFactory.ApplyQuickFix(Result);
+    if Assigned(Item) then begin
+      Result.Items.Add(Item);
+    end;
   finally
     FreeAndNil(MenuItemFactory);
   end;

--- a/client/source/DelphiLintClient280.dpk
+++ b/client/source/DelphiLintClient280.dpk
@@ -66,7 +66,8 @@ contains
   DelphiLint.HtmlGen in 'DelphiLint.HtmlGen.pas',
   DelphiLint.ExtWebView2 in 'DelphiLint.ExtWebView2.pas',
   DelphiLint.LiveData in 'DelphiLint.LiveData.pas',
-  DelphiLint.IssueActions in 'DelphiLint.IssueActions.pas';
+  DelphiLint.IssueActions in 'DelphiLint.IssueActions.pas',
+  DelphiLint.PopupHook in 'DelphiLint.PopupHook.pas';
 
 {$R DelphiLintClientAdditional.res}
 

--- a/client/source/DelphiLintClient280.dproj
+++ b/client/source/DelphiLintClient280.dproj
@@ -138,6 +138,7 @@ $(PreBuildEvent)]]>
         <DCCReference Include="DelphiLint.ExtWebView2.pas"/>
         <DCCReference Include="DelphiLint.LiveData.pas"/>
         <DCCReference Include="DelphiLint.IssueActions.pas"/>
+        <DCCReference Include="DelphiLint.PopupHook.pas"/>
         <RcItem Include="..\assets\delphilint_icon_24x24.bmp">
             <ResourceType>BITMAP</ResourceType>
             <ResourceId>DL_SPLASH</ResourceId>

--- a/client/source/DelphiLintClient290.dpk
+++ b/client/source/DelphiLintClient290.dpk
@@ -66,7 +66,8 @@ contains
   DelphiLint.HtmlGen in 'DelphiLint.HtmlGen.pas',
   DelphiLint.ExtWebView2 in 'DelphiLint.ExtWebView2.pas',
   DelphiLint.LiveData in 'DelphiLint.LiveData.pas',
-  DelphiLint.IssueActions in 'DelphiLint.IssueActions.pas';
+  DelphiLint.IssueActions in 'DelphiLint.IssueActions.pas',
+  DelphiLint.PopupHook in 'DelphiLint.PopupHook.pas';
 
 {$R DelphiLintClientAdditional.res}
 

--- a/client/source/DelphiLintClient290.dproj
+++ b/client/source/DelphiLintClient290.dproj
@@ -139,6 +139,7 @@ $(PreBuildEvent)]]>
         <DCCReference Include="DelphiLint.ExtWebView2.pas"/>
         <DCCReference Include="DelphiLint.LiveData.pas"/>
         <DCCReference Include="DelphiLint.IssueActions.pas"/>
+        <DCCReference Include="DelphiLint.PopupHook.pas"/>
         <RcItem Include="..\assets\delphilint_icon_24x24.bmp">
             <ResourceType>BITMAP</ResourceType>
             <ResourceId>DL_SPLASH</ResourceId>

--- a/client/test/DelphiLintTest.Handlers.pas
+++ b/client/test/DelphiLintTest.Handlers.pas
@@ -82,6 +82,7 @@ implementation
 
 uses
     System.SysUtils
+  , Vcl.Menus
   , DelphiLint.Handlers
   , DelphiLint.Context
   , DelphiLintTest.MockContext
@@ -408,6 +409,7 @@ begin
   TMock.Construct<IIDEEditLineTracker, TMockEditLineTracker>(MockLineTracker);
   MockLineTracker.MockedFileName := CFileName;
   MockView.MockedLineTracker := MockLineTracker;
+  MockView.MockedContextMenu := TPopupMenu.Create(nil);
 
   Handler := TEditorHandler.Create;
   try
@@ -449,6 +451,7 @@ begin
   TMock.Construct<IIDEEditLineTracker, TMockEditLineTracker>(MockLineTracker);
   MockLineTracker.MockedFileName := CFileName;
   MockView.MockedLineTracker := MockLineTracker;
+  MockView.MockedContextMenu := TPopupMenu.Create(nil);
 
   Handler := TEditorHandler.Create;
   try
@@ -499,6 +502,7 @@ begin
   TMock.Construct<IIDEEditLineTracker, TMockEditLineTracker>(MockLineTracker);
   MockLineTracker.MockedFileName := 'abc.pas';
   MockView.MockedLineTracker := MockLineTracker;
+  MockView.MockedContextMenu := TPopupMenu.Create(nil);
 
   Handler := TEditorHandler.Create;
   try

--- a/companion/delphilint-vscode/src/settings.ts
+++ b/companion/delphilint-vscode/src/settings.ts
@@ -130,7 +130,7 @@ export function getSonarDelphiVersion(): string {
   if (override) {
     return override;
   } else {
-    return "1.4.0";
+    return "1.5.0";
   }
 }
 

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/analysis/DelphiIssue.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/analysis/DelphiIssue.java
@@ -18,6 +18,8 @@
 package au.com.integradev.delphilint.analysis;
 
 import au.com.integradev.delphilint.remote.IssueStatus;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.sonarsource.sonarlint.core.analysis.api.Issue;
 
 public class DelphiIssue {
@@ -26,6 +28,7 @@ public class DelphiIssue {
   private String file;
   private TextRange range;
   private RemoteMetadata metadata;
+  private List<DelphiQuickFix> quickFixes;
 
   public DelphiIssue(Issue issue, RemoteMetadata metadata) {
     var textRange = issue.getTextRange();
@@ -41,6 +44,8 @@ public class DelphiIssue {
                 textRange.getEndLine(),
                 textRange.getEndLineOffset());
     this.metadata = metadata;
+    this.quickFixes =
+        issue.quickFixes().stream().map(DelphiQuickFix::new).collect(Collectors.toList());
   }
 
   public DelphiIssue(
@@ -74,6 +79,10 @@ public class DelphiIssue {
 
   public RemoteMetadata getMetadata() {
     return metadata;
+  }
+
+  public List<DelphiQuickFix> getQuickFixes() {
+    return quickFixes;
   }
 
   public static class RemoteMetadata {

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/analysis/DelphiQuickFix.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/analysis/DelphiQuickFix.java
@@ -1,0 +1,61 @@
+/*
+ * DelphiLint Server
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package au.com.integradev.delphilint.analysis;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sonarsource.sonarlint.core.analysis.api.ClientInputFileEdit;
+import org.sonarsource.sonarlint.core.analysis.api.QuickFix;
+
+public class DelphiQuickFix {
+  private static final Logger LOG = LogManager.getLogger(DelphiQuickFix.class);
+
+  private final String message;
+  private final List<DelphiTextEdit> textEdits;
+
+  public DelphiQuickFix(QuickFix quickFix) {
+    message = quickFix.message();
+
+    if (quickFix.inputFileEdits().size() > 1) {
+      LOG.warn("A quick fix attempted to edit more than one file, which is unsupported");
+    }
+
+    textEdits =
+        quickFix.inputFileEdits().stream()
+            .findFirst()
+            .map(DelphiQuickFix::convertInputFileEdit)
+            .orElse(Collections.emptyList());
+  }
+
+  private static List<DelphiTextEdit> convertInputFileEdit(ClientInputFileEdit fileEdit) {
+    return fileEdit.textEdits().stream()
+        .map(edit -> new DelphiTextEdit(edit.newText(), new TextRange(edit.range())))
+        .collect(Collectors.toList());
+  }
+
+  public String message() {
+    return message;
+  }
+
+  public List<DelphiTextEdit> textEdits() {
+    return textEdits;
+  }
+}

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/analysis/DelphiTextEdit.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/analysis/DelphiTextEdit.java
@@ -1,0 +1,36 @@
+/*
+ * DelphiLint Server
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package au.com.integradev.delphilint.analysis;
+
+public class DelphiTextEdit {
+  private String replacement;
+  private TextRange range;
+
+  public DelphiTextEdit(String replacement, TextRange range) {
+    this.replacement = replacement;
+    this.range = range;
+  }
+
+  public String replacement() {
+    return replacement;
+  }
+
+  public TextRange range() {
+    return range;
+  }
+}

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/server/message/data/QuickFixData.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/server/message/data/QuickFixData.java
@@ -17,58 +17,23 @@
  */
 package au.com.integradev.delphilint.server.message.data;
 
-import au.com.integradev.delphilint.analysis.TextRange;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-public class IssueData {
-  @JsonProperty private String ruleKey;
+public class QuickFixData {
   @JsonProperty private String message;
-  @JsonProperty private String file;
-  @JsonProperty private TextRange range;
-  @JsonProperty private IssueMetadataData metadata;
-  @JsonProperty private List<QuickFixData> quickFixes;
+  @JsonProperty private List<TextEditData> textEdits;
 
-  public IssueData(
-      String ruleKey,
-      String message,
-      String file,
-      TextRange range,
-      IssueMetadataData metadata,
-      List<QuickFixData> quickFixes) {
-    this.ruleKey = ruleKey;
+  public QuickFixData(String message, List<TextEditData> textEdits) {
     this.message = message;
-    this.file = file;
-    this.range = range;
-    this.metadata = metadata;
-    this.quickFixes = quickFixes;
-  }
-
-  public String getRuleKey() {
-    return ruleKey;
+    this.textEdits = textEdits;
   }
 
   public String getMessage() {
     return message;
   }
 
-  public String getFile() {
-    return file;
-  }
-
-  public void setFile(String file) {
-    this.file = file;
-  }
-
-  public TextRange getRange() {
-    return range;
-  }
-
-  public IssueMetadataData getMetadata() {
-    return metadata;
-  }
-
-  public List<QuickFixData> getQuickFixes() {
-    return quickFixes;
+  public List<TextEditData> getTextEdits() {
+    return textEdits;
   }
 }

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/server/message/data/TextEditData.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/server/message/data/TextEditData.java
@@ -19,56 +19,21 @@ package au.com.integradev.delphilint.server.message.data;
 
 import au.com.integradev.delphilint.analysis.TextRange;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
 
-public class IssueData {
-  @JsonProperty private String ruleKey;
-  @JsonProperty private String message;
-  @JsonProperty private String file;
+public class TextEditData {
+  @JsonProperty private String replacement;
   @JsonProperty private TextRange range;
-  @JsonProperty private IssueMetadataData metadata;
-  @JsonProperty private List<QuickFixData> quickFixes;
 
-  public IssueData(
-      String ruleKey,
-      String message,
-      String file,
-      TextRange range,
-      IssueMetadataData metadata,
-      List<QuickFixData> quickFixes) {
-    this.ruleKey = ruleKey;
-    this.message = message;
-    this.file = file;
+  public TextEditData(String replacement, TextRange range) {
+    this.replacement = replacement;
     this.range = range;
-    this.metadata = metadata;
-    this.quickFixes = quickFixes;
   }
 
-  public String getRuleKey() {
-    return ruleKey;
+  public String replacement() {
+    return replacement;
   }
 
-  public String getMessage() {
-    return message;
-  }
-
-  public String getFile() {
-    return file;
-  }
-
-  public void setFile(String file) {
-    this.file = file;
-  }
-
-  public TextRange getRange() {
+  public TextRange range() {
     return range;
-  }
-
-  public IssueMetadataData getMetadata() {
-    return metadata;
-  }
-
-  public List<QuickFixData> getQuickFixes() {
-    return quickFixes;
   }
 }


### PR DESCRIPTION
As of integrated-application-development/sonar-delphi#215 and [release 1.5.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.5.0), SonarDelphi outputs automated fixes in a number of cases.

This PR adds support for applying these quick fixes in two ways: via right click on the issue range, and via right click on the issue entry.

One quick fix:

![image](https://github.com/integrated-application-development/delphilint/assets/28214458/632008cd-c087-43fd-b02b-af2d050222d1)

![image](https://github.com/integrated-application-development/delphilint/assets/28214458/3c8abef7-90f4-4fc0-b9f4-6aa887b15eff)

Multiple quick fixes:

![image](https://github.com/integrated-application-development/delphilint/assets/28214458/31e8c7ad-a3a6-4d17-b07a-cdac48e1753e)

![image](https://github.com/integrated-application-development/delphilint/assets/28214458/e5b7ef82-6ae7-40d9-ab87-f0f41abb0a1a)