### PR TITLE
Free line trackers when buffer is freed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   issues reported.
 * Multiline issues now display their underlines correctly.
 * Right clicking the separator between the issue view and rule view no longer prevents the separator from being moved.
+* Issue line trackers are now invalidated when the backing IDE buffer is freed.
 
 ## [1.0.2] - 2024-04-02
 

--- a/client/source/DelphiLint.Context.pas
+++ b/client/source/DelphiLint.Context.pas
@@ -92,6 +92,7 @@ type
 
   IIDEModule = interface;
   IIDEEditLineTracker = interface;
+  IIDEHandler = interface;
   IIDEViewHandler = interface;
 
   IIDEEditView = interface
@@ -102,6 +103,8 @@ type
     function GetLineTracker: IIDEEditLineTracker;
     function AddNotifier(Notifier: IIDEViewHandler): Integer;
     procedure RemoveNotifier(Index: Integer);
+    function AddBufferNotifier(Notifier: IIDEHandler): Integer;
+    procedure RemoveBufferNotifier(Index: Integer);
     function GetLeftColumn: Integer;
     procedure ReplaceText(
       Replacement: string;

--- a/client/source/DelphiLint.IDEContext.pas
+++ b/client/source/DelphiLint.IDEContext.pas
@@ -158,6 +158,8 @@ type
     function GetLineTracker: IIDEEditLineTracker;
     function AddNotifier(Notifier: IIDEViewHandler): Integer;
     procedure RemoveNotifier(Index: Integer);
+    function AddBufferNotifier(Notifier: IIDEHandler): Integer;
+    procedure RemoveBufferNotifier(Index: Integer);
     function GetLeftColumn: Integer;
     procedure ReplaceText(
       Replacement: string;
@@ -629,6 +631,16 @@ end;
 procedure TToolsApiEditView.Paint;
 begin
   FRaw.Paint;
+end;
+
+function TToolsApiEditView.AddBufferNotifier(Notifier: IIDEHandler): Integer;
+begin
+  Result := FRaw.Buffer.AddNotifier(TToolsApiNotifier<IIDEHandler>.Create(Notifier));
+end;
+
+procedure TToolsApiEditView.RemoveBufferNotifier(Index: Integer);
+begin
+  FRaw.Buffer.RemoveNotifier(Index);
 end;
 
 function TToolsApiEditView.AddNotifier(Notifier: IIDEViewHandler): Integer;

--- a/client/test/DelphiLintTest.Handlers.pas
+++ b/client/test/DelphiLintTest.Handlers.pas
@@ -73,8 +73,8 @@ type
     procedure TestIssueLineUpdatedWhenTrackedLineChanged;
     [Test]
     procedure TestActivatedViewDoesNotDoubleInitTracker;
-    [Test]
     [TestCase('OnViewActivated', 'activated')]
+    [TestCase('OnViewAdded', 'added')]
     procedure TestNewViewInitsTracker(NewType: string);
   end;
 

--- a/client/test/DelphiLintTest.MockContext.pas
+++ b/client/test/DelphiLintTest.MockContext.pas
@@ -107,6 +107,7 @@ type
     FFileName: string;
     FLineTracker: IIDEEditLineTracker;
     FNotifiers: TDictionary<Integer, IIDEViewHandler>;
+    FBufferNotifiers: TDictionary<Integer, IIDEHandler>;
     FNextId: Integer;
     FLeftColumn: Integer;
     FColumn: Integer;
@@ -122,6 +123,8 @@ type
     function GetLineTracker: IIDEEditLineTracker;
     function AddNotifier(Notifier: IIDEViewHandler): Integer;
     procedure RemoveNotifier(Index: Integer);
+    function AddBufferNotifier(Notifier: IIDEHandler): Integer;
+    procedure RemoveBufferNotifier(Index: Integer);
     function GetLeftColumn: Integer;
     procedure ReplaceText(
       Replacement: string;
@@ -137,6 +140,7 @@ type
     property MockedFileName: string read FFileName write FFileName;
     property MockedLineTracker: IIDEEditLineTracker read FLineTracker write FLineTracker;
     property MockedNotifiers: TDictionary<Integer, IIDEViewHandler> read FNotifiers write FNotifiers;
+    property MockedBufferNotifiers: TDictionary<Integer, IIDEHandler> read FBufferNotifiers write FBufferNotifiers;
     property MockedLeftColumn: Integer read FLeftColumn write FLeftColumn;
     property MockedRow: Integer read FRow write FRow;
     property MockedColumn: Integer read FColumn write FColumn;
@@ -1178,13 +1182,22 @@ constructor TMockEditView.Create;
 begin
   inherited;
   FNotifiers := TDictionary<Integer, IIDEViewHandler>.Create;
+  FBufferNotifiers := TDictionary<Integer, IIDEHandler>.Create;
 end;
 
 destructor TMockEditView.Destroy;
 begin
   FreeAndNil(FNotifiers);
+  FreeAndNil(FBufferNotifiers);
   FreeAndNil(FContextMenu);
   inherited;
+end;
+
+function TMockEditView.AddBufferNotifier(Notifier: IIDEHandler): Integer;
+begin
+  FBufferNotifiers.Add(FNextId, Notifier);
+  Result := FNextId;
+  FNextId := FNextId + 1;
 end;
 
 function TMockEditView.AddNotifier(Notifier: IIDEViewHandler): Integer;
@@ -1232,6 +1245,11 @@ end;
 procedure TMockEditView.Paint;
 begin
   NotifyEvent(evcPaint, []);
+end;
+
+procedure TMockEditView.RemoveBufferNotifier(Index: Integer);
+begin
+  FNotifiers.Remove(Index);
 end;
 
 procedure TMockEditView.RemoveNotifier(Index: Integer);


### PR DESCRIPTION
This PR hooks the IDE edit view's buffer object to ensure that any associated line trackers are freed when the view itself is freed.
This is a potential cause of #6, but I hesitate to say that it's fixed since it isn't reproducible.