### PR TITLE
Improve wording around selecting a Java executable path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changes in issue validity are now immediately reflected across the UI.
 * The issue view has been redesigned for improved performance and utility.
 * The default SonarDelphi version is now [1.5.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.5.0).
+* Phrasing around manually choosing a Java executable has been changed to "Browse" instead of "Select override".
 
 ### Fixed
 

--- a/client/source/DelphiLint.SetupForm.dfm
+++ b/client/source/DelphiLint.SetupForm.dfm
@@ -118,7 +118,7 @@ object LintSetupForm: TLintSetupForm
     object OkButton: TButton
       Left = 32
       Top = 251
-      Width = 405
+      Width = 401
       Height = 35
       Anchors = [akLeft, akTop, akRight]
       Caption = 'Apply this configuration'
@@ -128,7 +128,7 @@ object LintSetupForm: TLintSetupForm
     object RefreshButton: TButton
       Left = 32
       Top = 221
-      Width = 405
+      Width = 401
       Height = 24
       Anchors = [akLeft, akTop, akRight]
       Caption = 'Refresh'
@@ -138,16 +138,16 @@ object LintSetupForm: TLintSetupForm
     object JavaExeBrowseButton: TButton
       Left = 32
       Top = 122
-      Width = 97
+      Width = 65
       Height = 21
-      Caption = 'Select override'
+      Caption = 'Browse'
       TabOrder = 1
       OnClick = JavaExeBrowseButtonClick
     end
     object ServerJarIndicator: TPanel
       Left = 32
       Top = 177
-      Width = 405
+      Width = 401
       Height = 30
       Alignment = taLeftJustify
       Anchors = [akLeft, akTop, akRight]
@@ -162,7 +162,7 @@ object LintSetupForm: TLintSetupForm
     object JavaExeIndicator: TPanel
       Left = 32
       Top = 86
-      Width = 405
+      Width = 401
       Height = 30
       Alignment = taLeftJustify
       Anchors = [akLeft, akTop, akRight]
@@ -175,11 +175,11 @@ object LintSetupForm: TLintSetupForm
       StyleElements = []
     end
     object JavaExeClearButton: TButton
-      Left = 135
+      Left = 103
       Top = 122
-      Width = 186
+      Width = 146
       Height = 21
-      Caption = 'Clear override (use JAVA_HOME)'
+      Caption = 'Clear (use JAVA_HOME)'
       TabOrder = 5
       OnClick = JavaExeClearButtonClick
     end

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,6 +11,8 @@
   - [Error: "Could not connect to the configured SonarQube instance."](#error-could-not-connect-to-the-configured-sonarqube-instance)
   - [Error: "SonarDelphi could not be retrieved from GitHub."](#error-sonardelphi-could-not-be-retrieved-from-github)
   - [Fixing invalid SSL certificates](#fixing-invalid-ssl-certificates)
+  - [DelphiLint fails, saying that the server failed to communicate the port.](#delphilint-fails-saying-that-the-server-failed-to-communicate-the-port)
+  - [DelphiLint can't find my Java executable / is using the wrong Java executable.](#delphilint-cant-find-my-java-executable--is-using-the-wrong-java-executable)
 
 ## General
 
@@ -105,3 +107,22 @@ trusted certificates). This can be done in two ways:
   ```
 
 For more information, see this [blog post](https://chancharles.medium.com/java-consultant-tip-ssl-certificates-and-man-in-the-middle-ssl-proxy-3867b81ee5f0).
+
+### DelphiLint fails, saying that the server failed to communicate the port.
+
+This is usually due to the server failing to start on the provided Java version. Please ensure that the version
+of Java that is being used is version 11 or higher, since DelphiLint uses Java 11 features and is compiled with
+Java 11.
+
+If multiple Java installations are installed and DelphiLint is choosing the wrong one, it is recommended to manually
+specify the path to the desired Java 11+ executable
+(see [below](#delphilint-cant-find-my-java-executable--is-using-the-wrong-java-executable)).
+
+### DelphiLint can't find my Java executable / is using the wrong Java executable.
+
+Most Java installations set the `JAVA_HOME` environment variable, which points to the root directory of the Java
+installation. If this variable is present, DelphiLint defaults to `%JAVA_HOME%\bin\java.exe`.
+
+It's also possible to manually specify the path to the Java executable if `JAVA_HOME` isn't present, or points to the
+wrong Java version. This can be done in the DelphiLint External Resources Setup window at
+`DelphiLint > Settings > Set up external resources`.


### PR DESCRIPTION
This PR updates the external resources setup to use the phrases:

- "Browse" instead of "Select override"
- "Clear" instead of "Clear override"

It also adds a new FAQ section on how to configure Java executable path.

Fixes #27 