### PR TITLE
Place Edge embed data folder under DelphiLint appdata dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Multiline issues now display their underlines correctly.
 * Right clicking the separator between the issue view and rule view no longer prevents the separator from being moved.
 * Issue line trackers are now invalidated when the backing IDE buffer is freed.
+* Blank rule view on Delphi versions before 11.2.
+* Warnings when opening the rule view on Delphi versions before 11.2.
 
 ## [1.0.2] - 2024-04-02
 

--- a/client/source/DelphiLint.ToolFrame.pas
+++ b/client/source/DelphiLint.ToolFrame.pas
@@ -205,6 +205,7 @@ begin
   TThread.ForceQueue(
     TThread.Current,
     procedure begin
+      RuleBrowser.UserDataFolder := TPath.Combine(LintContext.Settings.SettingsDirectory, 'bds.exe.WebView2');
       RuleBrowser.CreateWebView;
     end);
 end;


### PR DESCRIPTION
This PR explicitly sets the Edge browser embed's user data folder to under `%APPDATA%\DelphiLint\bds.exe.WebView2`. This improves support for Delphi 11.0 and 11.1.

Fixes #34