### PR TITLE
Add tests for long string fields

### DIFF
--- a/client/test/DelphiLintClientTest280.dpr
+++ b/client/test/DelphiLintClientTest280.dpr
@@ -33,7 +33,8 @@ uses
   DelphiLintTest.HtmlGen in 'DelphiLintTest.HtmlGen.pas',
   DelphiLintTest.Settings in 'DelphiLintTest.Settings.pas',
   DelphiLintTest.LiveData in 'DelphiLintTest.LiveData.pas',
-  DelphiLintTest.IssueActions in 'DelphiLintTest.IssueActions.pas';
+  DelphiLintTest.IssueActions in 'DelphiLintTest.IssueActions.pas',
+  DelphiLintTest.Properties in 'DelphiLintTest.Properties.pas';
 
 {$R DelphiLintClientTestAdditional.res}
 

--- a/client/test/DelphiLintClientTest280.dproj
+++ b/client/test/DelphiLintClientTest280.dproj
@@ -150,6 +150,7 @@ $(PreBuildEvent)]]>
         <DCCReference Include="DelphiLintTest.Settings.pas"/>
         <DCCReference Include="DelphiLintTest.LiveData.pas"/>
         <DCCReference Include="DelphiLintTest.IssueActions.pas"/>
+        <DCCReference Include="DelphiLintTest.Properties.pas"/>
         <RcItem Include="..\assets\delphilint_icon_24x24.bmp">
             <ResourceType>BITMAP</ResourceType>
             <ResourceId>DL_SPLASH</ResourceId>

--- a/client/test/DelphiLintClientTest290.dpr
+++ b/client/test/DelphiLintClientTest290.dpr
@@ -33,7 +33,8 @@ uses
   DelphiLintTest.HtmlGen in 'DelphiLintTest.HtmlGen.pas',
   DelphiLintTest.Settings in 'DelphiLintTest.Settings.pas',
   DelphiLintTest.LiveData in 'DelphiLintTest.LiveData.pas',
-  DelphiLintTest.IssueActions in 'DelphiLintTest.IssueActions.pas';
+  DelphiLintTest.IssueActions in 'DelphiLintTest.IssueActions.pas',
+  DelphiLintTest.Properties in 'DelphiLintTest.Properties.pas';
 
 {$R DelphiLintClientTestAdditional.res}
 

--- a/client/test/DelphiLintClientTest290.dproj
+++ b/client/test/DelphiLintClientTest290.dproj
@@ -151,6 +151,7 @@ $(PreBuildEvent)]]>
         <DCCReference Include="DelphiLintTest.Settings.pas"/>
         <DCCReference Include="DelphiLintTest.LiveData.pas"/>
         <DCCReference Include="DelphiLintTest.IssueActions.pas"/>
+        <DCCReference Include="DelphiLintTest.Properties.pas"/>
         <RcItem Include="..\assets\delphilint_icon_24x24.bmp">
             <ResourceType>BITMAP</ResourceType>
             <ResourceId>DL_SPLASH</ResourceId>

--- a/client/test/DelphiLintTest.Properties.pas
+++ b/client/test/DelphiLintTest.Properties.pas
@@ -1,0 +1,204 @@
+{
+DelphiLint Client
+Copyright (C) 2024 Integrated Application Development
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+}
+unit DelphiLintTest.Properties;
+
+interface
+
+uses
+    DUnitX.TestFramework
+  ;
+
+type
+  [TestFixture]
+  TPropertiesTest = class(TObject)
+  public
+    [Test]
+    procedure TestLongStringField;
+    [Test]
+    procedure TestLongStringFieldCleansUpWhenShortened;
+    [Test]
+    procedure TestEmptyLongStringField;
+    [Test]
+    procedure TestLongStringFieldMigrationPath;
+  end;
+
+implementation
+
+uses
+    DelphiLint.Properties
+  , System.SysUtils
+  , System.IniFiles
+  , System.IOUtils
+  ;
+
+//______________________________________________________________________________________________________________________
+
+procedure TPropertiesTest.TestEmptyLongStringField;
+const
+  CSection = 'FooSection';
+  CKey = 'BarKey';
+  CSizeKey = 'BarKey_Size';
+  CDefault = '<DEFAULT>';
+var
+  Field: TLongStringPropField;
+  Ini: TIniFile;
+  Path: String;
+begin
+  Path := TPath.GetTempFileName;
+  TFile.WriteAllText(Path, '', TEncoding.ASCII); // Clear file
+  Ini := TIniFile.Create(Path);
+  Field := TLongStringPropField.Create(CSection, CKey);
+  try
+    Field.Value := '';
+    Field.Save(Ini);
+    Assert.IsFalse(Ini.ValueExists(CSection, CKey));
+    Assert.AreEqual('1', Ini.ReadString(CSection, CSizeKey, CDefault));
+    Assert.AreEqual('', Ini.ReadString(CSection, CKey + '_0', CDefault));
+  finally
+    FreeAndNil(Field);
+    FreeAndNil(Ini);
+    TFile.Delete(Path);
+  end;
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TPropertiesTest.TestLongStringField;
+const
+  CSection = 'FooSection';
+  CKey = 'BarKey';
+  CSizeKey = 'BarKey_Size';
+  CDefault = '<DEFAULT>';
+var
+  Field: TLongStringPropField;
+  Ini: TIniFile;
+  Path: String;
+  Expected: String;
+begin
+  Path := TPath.GetTempFileName;
+  TFile.WriteAllText(Path, '', TEncoding.ASCII); // Clear file
+  Ini := TIniFile.Create(Path);
+  Field := TLongStringPropField.Create(CSection, CKey);
+  try
+    Expected := StringOfChar('a', 1000);
+    Ini.WriteString(CSection, CSizeKey, '1');
+    Ini.WriteString(CSection, CKey + '_0', Expected);
+    Field.Load(Ini);
+    Assert.AreEqual<String>(Expected, Field.Value);
+
+    Ini.WriteString(CSection, CKey + '_1', StringOfChar('b', 1000));
+    Field.Load(Ini);
+    Assert.AreEqual<String>(Expected, Field.Value);
+
+    Ini.WriteString(CSection, CSizeKey, '2');
+    Expected := Expected + StringOfChar('b', 1000);
+    Field.Load(Ini);
+    Assert.AreEqual<String>(Expected, Field.Value);
+
+    Field.Value := StringOfChar('c', 6000);
+    Field.Save(Ini);
+    Expected := StringOfChar('c', 1024);
+    Assert.AreEqual('6', Ini.ReadString(CSection, CSizeKey, CDefault));
+    Assert.AreEqual(Expected, Ini.ReadString(CSection, CKey + '_0', CDefault));
+    Assert.AreEqual(Expected, Ini.ReadString(CSection, CKey + '_1', CDefault));
+    Assert.AreEqual(Expected, Ini.ReadString(CSection, CKey + '_2', CDefault));
+    Assert.AreEqual(Expected, Ini.ReadString(CSection, CKey + '_3', CDefault));
+    Assert.AreEqual(Expected, Ini.ReadString(CSection, CKey + '_4', CDefault));
+    Assert.AreEqual(StringOfChar('c', 880), Ini.ReadString(CSection, CKey + '_5', CDefault));
+  finally
+    FreeAndNil(Field);
+    FreeAndNil(Ini);
+    TFile.Delete(Path);
+  end;
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TPropertiesTest.TestLongStringFieldCleansUpWhenShortened;
+const
+  CSection = 'FooSection';
+  CKey = 'BarKey';
+  CSizeKey = 'BarKey_Size';
+  CDefault = '<DEFAULT>';
+var
+  Field: TLongStringPropField;
+  Ini: TIniFile;
+  Path: String;
+begin
+  Path := TPath.GetTempFileName;
+  TFile.WriteAllText(Path, '', TEncoding.ASCII); // Clear file
+  Ini := TIniFile.Create(Path);
+  Field := TLongStringPropField.Create(CSection, CKey);
+  try
+    Field.Value := StringOfChar('c', 6000);
+    Field.Save(Ini);
+    Assert.AreEqual(Ini.ReadString(CSection, CSizeKey, CDefault), '6');
+    Assert.AreEqual(StringOfChar('c', 1024), Ini.ReadString(CSection, CKey + '_3', CDefault));
+
+    Field.Value := StringOfChar('c', 3000);
+    Field.Save(Ini);
+    Assert.AreEqual(Ini.ReadString(CSection, CSizeKey, CDefault), '3');
+    Assert.IsFalse(Ini.ValueExists(CSection, CKey + '_3'));
+  finally
+    FreeAndNil(Field);
+    FreeAndNil(Ini);
+    TFile.Delete(Path);
+  end;
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TPropertiesTest.TestLongStringFieldMigrationPath;
+
+const
+  CSection = 'FooSection';
+  CKey = 'BarKey';
+  CSizeKey = 'BarKey_Size';
+  CDefault = '<DEFAULT>';
+var
+  Field: TLongStringPropField;
+  Ini: TIniFile;
+  Path: String;
+  Expected: String;
+begin
+  Path := TPath.GetTempFileName;
+  TFile.WriteAllText(Path, '', TEncoding.ASCII); // Clear file
+  Ini := TIniFile.Create(Path);
+  Field := TLongStringPropField.Create(CSection, CKey);
+  try
+    Expected := StringOfChar('a', 1000);
+    Ini.WriteString(CSection, CKey, Expected);
+    Field.Load(Ini);
+    Assert.AreEqual<String>(Expected, Field.Value);
+
+    Field.Save(Ini);
+    Assert.IsFalse(Ini.ValueExists(CSection, CKey));
+    Assert.AreEqual('1', Ini.ReadString(CSection, CSizeKey, CDefault));
+    Assert.AreEqual(Expected, Ini.ReadString(CSection, CKey + '_0', CDefault));
+  finally
+    FreeAndNil(Field);
+    FreeAndNil(Ini);
+    TFile.Delete(Path);
+  end;
+end;
+
+//______________________________________________________________________________________________________________________
+
+initialization
+  TDUnitX.RegisterTestFixture(TPropertiesTest);
+end.

--- a/client/test/DelphiLintTest.Settings.pas
+++ b/client/test/DelphiLintTest.Settings.pas
@@ -61,6 +61,8 @@ type
     [Test]
     procedure TestSonarHostTokensMigrationPath;
     [Test]
+    procedure TestDisabledRules;
+    [Test]
     procedure TestServerJvmOptions;
     [Test]
     procedure TestDefaultServerJvmOptionsUseSystemProxies;
@@ -389,6 +391,29 @@ begin
       'project2@https://sonar.foo.bar=token2,' +
       'project3@https://foo.sonar.baz=token3',
     GetSetting(CCategory, CName + '_0'));
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TSettingsTest.TestDisabledRules;
+const
+  CCategory = 'Standalone';
+  CName = 'DisabledRules';
+begin
+  Assert.AreEqual(0, FSettings.SonarHostTokensMap.Count);
+
+  SetSetting(CCategory, CName + '_Size', '1');
+  SetSetting(
+    CCategory,
+    CName + '_0',
+    'community-delphi:FooBar,community-delphi:BazBar');
+  FSettings.Load;
+  Assert.AreEqual('community-delphi:FooBar,community-delphi:BazBar', FSettings.StandaloneDisabledRules);
+
+  FSettings.StandaloneDisabledRules := 'community-delphi:FlimpFlarp';
+  FSettings.Save;
+  Assert.AreEqual('1', GetSetting(CCategory, CName + '_Size'));
+  Assert.AreEqual('community-delphi:FlimpFlarp', GetSetting(CCategory, CName + '_0'));
 end;
 
 //______________________________________________________________________________________________________________________


### PR DESCRIPTION
This PR adds some supplementary testing to the new settings file type introduced in #37. 
It also updates an outdated test that was failing.