### PR TITLE
Bump SonarDelphi default version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changes in issue validity are now immediately reflected across the UI.
 * The issue view has been redesigned for improved performance and utility.
 * The settings interface has been redesigned, improving usability and reducing unnecessary network calls.
-* The default SonarDelphi version is now [1.5.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.5.0).
+* The default SonarDelphi version is now [1.6.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.6.0).
 * Phrasing around manually choosing a Java executable has been changed to "Browse" instead of "Select override".
 
 ### Fixed

--- a/client/source/DelphiLint.Settings.pas
+++ b/client/source/DelphiLint.Settings.pas
@@ -175,7 +175,7 @@ end;
 
 function TLintSettings.GetDefaultSonarDelphiVersion: string;
 begin
-  Result := '1.5.0';
+  Result := '1.6.0';
 end;
 
 //______________________________________________________________________________________________________________________

--- a/companion/delphilint-vscode/src/settings.ts
+++ b/companion/delphilint-vscode/src/settings.ts
@@ -129,7 +129,7 @@ export function getSonarDelphiVersion(): string {
   if (override) {
     return override;
   } else {
-    return "1.5.0";
+    return "1.6.0";
   }
 }
 


### PR DESCRIPTION
This PR updates the default SonarDelphi version to 1.6.0. Release notes can be seen [here](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.6.0). This includes an ordering fix for the GroupedParameterDeclaration quick fix.