### PR TITLE
Fix blank Edge browser embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Error reporting has been improved around initialization of the rule view's Edge browser embed.
+
+### Fixed
+
+* Blank rule view when WebView2Loader.dll is not accessible from PATH.
+* Blank rule view when docked after being first initialized as a floating window.
+
 ## [1.1.0] - 2024-06-04
 
 ### Added

--- a/client/source/DelphiLint.Plugin.pas
+++ b/client/source/DelphiLint.Plugin.pas
@@ -118,6 +118,7 @@ implementation
 uses
     System.SysUtils
   , System.UITypes
+  , System.IOUtils
   , Vcl.ComCtrls
   , Vcl.Dialogs
   , Winapi.Windows
@@ -303,7 +304,12 @@ end;
 //______________________________________________________________________________________________________________________
 
 procedure TPluginCore.OnRegister;
+var
+  NewPath: string;
 begin
+  NewPath := TPath.Combine(LintContext.Settings.SettingsDirectory, 'bin') + ';' + GetEnvironmentVariable('PATH');
+  SetEnvironmentVariable(PWideChar('PATH'), PWideChar(NewPath));
+
   // Editor notifier
   FEditor := TEditorHandler.Create;
   FEditor.OnOwnerFreed.AddListener(

--- a/client/source/DelphiLint.ToolFrame.pas
+++ b/client/source/DelphiLint.ToolFrame.pas
@@ -274,6 +274,10 @@ begin
   if RulePanel.Left < 10 then begin
     RulePanel.Width := Width div 2;
   end;
+
+  if not RuleBrowser.WebViewCreated then begin
+    RuleBrowser.ReinitializeWebView;
+  end;
 end;
 
 //______________________________________________________________________________________________________________________

--- a/scripts/TEMPLATE_install.ps1
+++ b/scripts/TEMPLATE_install.ps1
@@ -57,14 +57,6 @@ function Get-WebView2 {
     $Archive.Dispose()
   }
 
-  $DirsOnPath = $env:Path -split ";"
-  if ($DirsOnPath -icontains $BinFolder) {
-    Write-Host "Bin directory is already on user path."
-  } else {
-    [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$BinFolder", [System.EnvironmentVariableTarget]::User)
-    Write-Host "Added bin directory to user path."
-  }
-
   Remove-Item $TempFolder -Recurse -Force -ErrorAction Continue
 }
 


### PR DESCRIPTION
This PR fixes two separate problems that were causing the Edge browser embed to fail to display in some situations.

* The path to the Edge DLL is now added to the process PATH when the plugin is loaded, rather than by the installer. This fixes cases in which the PATH would not be fully interpreted if it was more than 2047 characters, causing the DLL to be missed.
* The web view is now reinitialized on DelphiLint form resize. This fixes #46.
  * For whatever reason, most of the events on the DelphiLint frame don't seem to get called. This is one of the few events that is reliably called when the form is docked.

Should also fix #45 