### PR TITLE
Fix various QA issues

### DIFF
--- a/client/sonar-project.properties
+++ b/client/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=delphilint-client
 sonar.projectName=DelphiLint Client
 sonar.projectBaseDir=.
 
+sonar.sourceEncoding=utf-8
 sonar.sources=source
 sonar.tests=test
 sonar.exclusions=**/__history/**,**/__recovery/**,**/target/**

--- a/client/source/DelphiLint.Analyzer.pas
+++ b/client/source/DelphiLint.Analyzer.pas
@@ -235,11 +235,11 @@ end;
 constructor TAnalyzerImpl.Create;
 begin
   inherited;
-  FActiveIssues := TObjectDictionary<string, TList<ILiveIssue>>.Create;
+  FActiveIssues := TObjectDictionary<string, TList<ILiveIssue>>.Create([doOwnsValues]);
   FCurrentAnalysis := nil;
   FFileAnalyses := TDictionary<string, TFileAnalysisHistory>.Create;
   FOnAnalysisStateChanged := TEventNotifier<TAnalysisStateChangeContext>.Create;
-  FRules := TObjectDictionary<string, TRule>.Create;
+  FRules := TObjectDictionary<string, TRule>.Create([doOwnsValues]);
   FServerThread := TLintServerThread.Create;
   FServerThread.FreeOnTerminate := False;
 end;

--- a/client/source/DelphiLint.Properties.pas
+++ b/client/source/DelphiLint.Properties.pas
@@ -72,7 +72,7 @@ type
     procedure Load(IniFile: TIniFile); override;
   end;
 
-  TPropertiesFile = class(TInterfacedObject)
+  TPropertiesFile = class(TObject)
   private
     FPath: string;
     FFields: TArray<TPropFieldBase>;

--- a/client/source/DelphiLint.Resources.pas
+++ b/client/source/DelphiLint.Resources.pas
@@ -82,8 +82,8 @@ constructor TLintResources.Create;
 begin
   inherited;
 
-  FLoadedPngs := TObjectDictionary<string, TPngImage>.Create;
-  FLoadedBitmaps := TObjectDictionary<string, TBitmap>.Create;
+  FLoadedPngs := TObjectDictionary<string, TPngImage>.Create([doOwnsValues]);
+  FLoadedBitmaps := TObjectDictionary<string, TBitmap>.Create([doOwnsValues]);
   FLoadedStrings := TDictionary<string, string>.Create;
 end;
 

--- a/client/source/DelphiLint.Server.pas
+++ b/client/source/DelphiLint.Server.pas
@@ -583,7 +583,7 @@ procedure TLintServer.OnRuleRetrieveResponse(
   var
     Pair: TJSONPair;
   begin
-    Result := TObjectDictionary<string, TRule>.Create;
+    Result := TObjectDictionary<string, TRule>.Create([doOwnsValues]);
     for Pair in Json do begin
       Result.Add(Pair.JsonString.Value, TRule.CreateFromJson(TJSONObject(Pair.JsonValue)));
     end;

--- a/client/test/DelphiLintTest.Plugin.pas
+++ b/client/test/DelphiLintTest.Plugin.pas
@@ -31,8 +31,6 @@ type
     procedure MockAllToolBars(IDEServices: TMockIDEServices);
     procedure BuildMockedContext(out IDEServices: TMockIDEServices);
   public
-    [Setup]
-    procedure Setup;
     [TearDown]
     procedure TearDown;
 
@@ -73,13 +71,6 @@ uses
   , DelphiLint.SetupForm
   , DelphiLint.OptionsForm
   ;
-
-//______________________________________________________________________________________________________________________
-
-procedure TIDEPluginTest.Setup;
-begin
-  MockContext.Reset;
-end;
 
 //______________________________________________________________________________________________________________________
 

--- a/client/test/DelphiLintTest.Utils.pas
+++ b/client/test/DelphiLintTest.Utils.pas
@@ -362,12 +362,15 @@ var
   IDEServices: TMockIDEServices;
   Project: TMockProject;
   ProjectDir: string;
-  ProjectOptions: TLintProjectOptions;
 begin
   MockIDEServices(IDEServices);
-  ProjectOptions := TLintProjectOptions.Create(CProjectOptionsFile, True);
-  MockContext.MockProjectOptions(CProjectFile, ProjectOptions);
-  ProjectOptions.AnalysisBaseDir := CProjectDirRelative;
+  MockContext.MockProjectOptions(
+    CProjectFile,
+    function: TLintProjectOptions
+    begin
+      Result := TLintProjectOptions.Create(CProjectOptionsFile, True);
+      Result.AnalysisBaseDir := CProjectDirRelative;
+    end);
 
   Project := TMockProject.Create;
   IDEServices.MockActiveProject(Project);

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/remote/standalone/AbstractStandaloneSonarHost.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/remote/standalone/AbstractStandaloneSonarHost.java
@@ -110,8 +110,6 @@ public abstract class AbstractStandaloneSonarHost implements SonarHost {
     return SonarCharacteristics.latest();
   }
 
-  public abstract String getName();
-
   @Override
   public Map<String, String> getRuleNamesByRuleKey() {
     return getRules().stream().collect(Collectors.toMap(RemoteRule::getKey, RemoteRule::getName));

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/server/message/ResponseAnalyzeResult.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/server/message/ResponseAnalyzeResult.java
@@ -46,15 +46,14 @@ public final class ResponseAnalyzeResult {
     Set<IssueData> issues =
         delphiIssues.stream()
             .map(
-                delphiIssue -> {
-                  return new IssueData(
-                      delphiIssue.getRuleKey(),
-                      delphiIssue.getMessage(),
-                      delphiIssue.getFile(),
-                      transformRange(delphiIssue.getTextRange()),
-                      transformMetadata(delphiIssue.getMetadata()),
-                      transformQuickFixes(delphiIssue.getQuickFixes()));
-                })
+                delphiIssue ->
+                    new IssueData(
+                        delphiIssue.getRuleKey(),
+                        delphiIssue.getMessage(),
+                        delphiIssue.getFile(),
+                        transformRange(delphiIssue.getTextRange()),
+                        transformMetadata(delphiIssue.getMetadata()),
+                        transformQuickFixes(delphiIssue.getQuickFixes())))
             .collect(Collectors.toSet());
 
     return new ResponseAnalyzeResult(issues);


### PR DESCRIPTION
This PR:

- Fixes a number of outstanding Sonar issues across the client, server, and VS Code companion
- Refactors the quick fix reflow code to lower cognitive complexity (it's much more readable now)
- Fixes a number of minor memory leaks caused by not passing the `doOwnsValues` option to `TObjectDictionary<T>.Create`
- Sets the source encoding of the `delphilint-client` Sonar project to UTF-8