### PR TITLE
Replace Bearer authentication with HTTP Basic for SQ 9.9 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Incompatibility with SonarQube 9.9, by using the HTTP Basic authentication scheme instead of the Bearer scheme.
+
 ## [1.1.1] - 2024-06-11
 
 ### Changed


### PR DESCRIPTION
When a token is provided, DelphiLint currently uses the Bearer authentication scheme to authenticate with the SonarQube server. This is apparently not supported by SonarQube 9.9, see [9.9 docs:](https://docs.sonarsource.com/sonarqube/9.9/extension-guide/web-api/)

> The token is sent via the login field of HTTP basic authentication, without any password.

This PR alters the server to use HTTP Basic auth instead. This is possible as the latest version still supports the HTTP Basic scheme, see [10.6 docs:](https://docs.sonarsource.com/sonarqube/latest/user-guide/user-account/generating-and-using-tokens/)

> when invoking web services, pass the token using the bearer or basic HTTP authentication scheme