### PR TITLE
Update spotless-maven-plugin to 2.43.0 for Java 21 compatibility

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -100,7 +100,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.27.2</version>
+          <version>2.43.0</version>
           <configuration>
             <java>
               <googleJavaFormat>


### PR DESCRIPTION
This PR updates spotless for Java 21 compatibility - the current version is incompatible (see https://github.com/diffplug/spotless/issues/1791). This fixes the Java test issue seen in [#53](https://github.com/integrated-application-development/delphilint/issues/53#issuecomment-2196389048). 