### PR TITLE
Update google-java-format to 1.22.0 for Java 21 compatibility

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -104,7 +104,7 @@
           <configuration>
             <java>
               <googleJavaFormat>
-                <version>1.15.0</version>
+                <version>1.22.0</version>
                 <style>GOOGLE</style>
                 <reflowLongStrings>true</reflowLongStrings>
               </googleJavaFormat>


### PR DESCRIPTION
This PR updates the version of google-java-format - we currently use 1.15.0, and google-java-format versions below 1.17.0 are not compatible with Java 21.