### PR TITLE
Improve support for project analysis and global analysis tokens in Connected Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Project Options now prevents a blank server URL or project key when in Connected Mode.
+
 ### Fixed
 
 * Incompatibility with SonarQube 9.9, by using the HTTP Basic authentication scheme instead of the Bearer scheme.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Incompatibility with SonarQube 9.9, by using the HTTP Basic authentication scheme instead of the Bearer scheme.
+* Incompatibility with SonarQube project and global analysis tokens in Connected Mode.
 
 ## [1.1.1] - 2024-06-11
 

--- a/client/source/DelphiLint.ExternalConsts.pas
+++ b/client/source/DelphiLint.ExternalConsts.pas
@@ -1,0 +1,29 @@
+{
+DelphiLint Client
+Copyright (C) 2024 Integrated Application Development
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+}
+unit DelphiLint.ExternalConsts;
+
+interface
+
+const
+  CReleasesApiUrl = 'https://api.github.com/repos/integrated-application-development/sonar-delphi/releases';
+  CFaqUrl = 'https://github.com/integrated-application-development/delphilint/blob/master/docs/FAQ.md';
+  CTokenInfoUrl = CFaqUrl + '#how-do-i-authenticate-with-a-sonarqube-instance-in-connected-mode';
+
+implementation
+
+end.

--- a/client/source/DelphiLint.OptionsForm.dfm
+++ b/client/source/DelphiLint.OptionsForm.dfm
@@ -67,9 +67,9 @@ object LintOptionsForm: TLintOptionsForm
         Width = 234
         Height = 23
         Anchors = [akLeft, akTop, akRight]
-        EditLabel.Width = 56
+        EditLabel.Width = 61
         EditLabel.Height = 15
-        EditLabel.Caption = 'Server URL'
+        EditLabel.Caption = 'Server URL*'
         TabOrder = 0
         Text = ''
         OnChange = SonarHostUrlEditChange
@@ -93,9 +93,9 @@ object LintOptionsForm: TLintOptionsForm
         Width = 234
         Height = 23
         Anchors = [akLeft, akTop, akRight]
-        EditLabel.Width = 58
+        EditLabel.Width = 63
         EditLabel.Height = 15
-        EditLabel.Caption = 'Project key'
+        EditLabel.Caption = 'Project key*'
         TabOrder = 1
         Text = ''
         OnChange = SonarHostProjectKeyEditChange

--- a/client/source/DelphiLint.OptionsForm.pas
+++ b/client/source/DelphiLint.OptionsForm.pas
@@ -74,6 +74,7 @@ type
 
     procedure UpdateControls;
     procedure UpdateTokenInfo;
+    function Validate: Boolean;
   public
     procedure RefreshOptions;
     procedure RefreshTheme;
@@ -137,7 +138,6 @@ begin
     SonarHostDownloadPluginCheckBox.Checked := FProjectOptions.SonarHostDownloadPlugin;
     AnalysisBaseDirEdit.Text := FProjectOptions.AnalysisBaseDir;
     AnalysisReadPropertiesCheckBox.Checked := FProjectOptions.AnalysisReadProperties;
-    SaveButton.Enabled := True;
 
     ProjectName := TPath.GetFileName(FProjectFile);
     ProjectNameLabel.Caption := 'DelphiLint: ' + ProjectName;
@@ -149,12 +149,12 @@ begin
     SonarHostDownloadPluginCheckBox.Checked := False;
     AnalysisBaseDirEdit.Text := '';
     AnalysisReadPropertiesCheckBox.Checked := False;
-    SaveButton.Enabled := False;
 
     ProjectNameLabel.Caption := 'DelphiLint: (no project)';
     Caption := 'DelphiLint Project Options (no project)';
   end;
 
+  SaveButton.Enabled := Validate;
   UpdateTokenInfo;
 end;
 
@@ -242,6 +242,7 @@ begin
     FProjectOptions.SonarHostUrl := SonarHostUrlEdit.Text;
     UpdateTokenInfo;
   end;
+  SaveButton.Enabled := Validate;
 end;
 
 //______________________________________________________________________________________________________________________
@@ -261,6 +262,7 @@ begin
   if Assigned(FProjectOptions) then begin
     FProjectOptions.SonarHostProjectKey := SonarHostProjectKeyEdit.Text;
   end;
+  SaveButton.Enabled := Validate;
 end;
 
 //______________________________________________________________________________________________________________________
@@ -320,6 +322,18 @@ begin
     IsConnectedMode
     and (FProjectOptions.SonarHostProjectKey <> '')
     and IsUrl(FProjectOptions.SonarHostUrl);
+end;
+
+//______________________________________________________________________________________________________________________
+
+function TLintOptionsForm.Validate: Boolean;
+begin
+  if IsConnectedMode then begin
+    Result := (SonarHostUrlEdit.Text <> '') and (SonarHostProjectKeyEdit.Text <> '');
+  end
+  else begin
+    Result := True;
+  end;
 end;
 
 //______________________________________________________________________________________________________________________

--- a/client/source/DelphiLint.SettingsFrame.dfm
+++ b/client/source/DelphiLint.SettingsFrame.dfm
@@ -1,10 +1,10 @@
 object LintSettingsFrame: TLintSettingsFrame
   Left = 0
   Top = 0
-  Width = 439
+  Width = 772
   Height = 340
   Constraints.MinHeight = 340
-  Constraints.MinWidth = 400
+  Constraints.MinWidth = 420
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clBtnText
   Font.Height = -12
@@ -13,14 +13,14 @@ object LintSettingsFrame: TLintSettingsFrame
   ParentFont = False
   TabOrder = 0
   DesignSize = (
-    439
+    772
     340)
   object TopPageControl: TPageControl
     Left = 3
     Top = 3
-    Width = 433
+    Width = 769
     Height = 332
-    ActivePage = GeneralSheet
+    ActivePage = ConnectedSheet
     Anchors = [akLeft, akTop, akRight, akBottom]
     RaggedRight = True
     TabOrder = 0
@@ -30,7 +30,7 @@ object LintSettingsFrame: TLintSettingsFrame
       object GeneralPanel: TPanel
         Left = 0
         Top = 0
-        Width = 425
+        Width = 761
         Height = 302
         Align = alClient
         BevelOuter = bvNone
@@ -114,7 +114,7 @@ object LintSettingsFrame: TLintSettingsFrame
       object StandalonePanel: TPanel
         Left = 0
         Top = 0
-        Width = 425
+        Width = 761
         Height = 302
         Align = alClient
         BevelOuter = bvNone
@@ -122,7 +122,7 @@ object LintSettingsFrame: TLintSettingsFrame
         object StandaloneRulesListBox: TCheckListBox
           Left = 0
           Top = 185
-          Width = 425
+          Width = 761
           Height = 117
           Align = alClient
           ItemHeight = 15
@@ -132,7 +132,7 @@ object LintSettingsFrame: TLintSettingsFrame
         object Panel1: TPanel
           Left = 0
           Top = 0
-          Width = 425
+          Width = 761
           Height = 185
           Align = alTop
           BevelOuter = bvNone
@@ -219,7 +219,7 @@ object LintSettingsFrame: TLintSettingsFrame
         object PlaceholderStandaloneRulesPanel: TPanel
           Left = 0
           Top = 185
-          Width = 425
+          Width = 761
           Height = 117
           Align = alClient
           BevelOuter = bvNone
@@ -242,16 +242,16 @@ object LintSettingsFrame: TLintSettingsFrame
       object ConnectedPanel: TPanel
         Left = 0
         Top = 0
-        Width = 425
+        Width = 761
         Height = 302
         Align = alClient
         BevelOuter = bvNone
         TabOrder = 0
         object TokensGrid: TDBGrid
           Left = 25
-          Top = 33
-          Width = 400
-          Height = 269
+          Top = 73
+          Width = 736
+          Height = 229
           Align = alClient
           DataSource = TokensDataSource
           Options = [dgEditing, dgTitles, dgIndicator, dgRowLines, dgTabs, dgCancelOnExit]
@@ -284,15 +284,18 @@ object LintSettingsFrame: TLintSettingsFrame
               Visible = True
             end>
         end
-        object Panel2: TPanel
+        object ConnectedTopPanel: TPanel
           Left = 0
           Top = 0
-          Width = 425
-          Height = 33
+          Width = 761
+          Height = 73
           Align = alTop
           BevelOuter = bvNone
           TabOrder = 1
-          object Label3: TLabel
+          DesignSize = (
+            761
+            73)
+          object AuthHeaderLabel: TLabel
             Left = 13
             Top = 8
             Width = 166
@@ -305,12 +308,60 @@ object LintSettingsFrame: TLintSettingsFrame
             Font.Style = []
             ParentFont = False
           end
+          object TokenNotePanel: TPanel
+            AlignWithMargins = True
+            Left = 25
+            Top = 33
+            Width = 736
+            Height = 32
+            Margins.Left = 10
+            Margins.Top = 10
+            Margins.Right = 10
+            Margins.Bottom = 10
+            Anchors = [akLeft, akTop, akRight]
+            BevelOuter = bvNone
+            Padding.Left = 4
+            Padding.Top = 4
+            Padding.Right = 4
+            Padding.Bottom = 4
+            ParentBackground = False
+            TabOrder = 0
+            object TokenNoteLabel: TLabel
+              AlignWithMargins = True
+              Left = 9
+              Top = 8
+              Width = 620
+              Height = 20
+              Margins.Left = 5
+              Margins.Top = 4
+              Align = alClient
+              Caption = 
+                'User-level tokens (squ_...) are recommended for full compatibility.'
+              Font.Charset = DEFAULT_CHARSET
+              Font.Color = clBtnText
+              Font.Height = -12
+              Font.Name = 'Segoe UI'
+              Font.Style = []
+              ParentFont = False
+            end
+            object LearnMoreButton: TButton
+              Left = 632
+              Top = 4
+              Width = 100
+              Height = 24
+              Margins.Left = 5
+              Align = alRight
+              Caption = 'Learn more...'
+              TabOrder = 0
+              OnClick = LearnMoreButtonClick
+            end
+          end
         end
         object Panel3: TPanel
           Left = 0
-          Top = 33
+          Top = 73
           Width = 25
-          Height = 269
+          Height = 229
           Align = alLeft
           BevelOuter = bvNone
           TabOrder = 2
@@ -335,8 +386,8 @@ object LintSettingsFrame: TLintSettingsFrame
   end
   object TokensDataSource: TDataSource
     DataSet = TokensDataSet
-    Left = 268
-    Top = 74
+    Left = 124
+    Top = 178
   end
   object TokensDataSet: TClientDataSet
     Aggregates = <>

--- a/client/source/DelphiLint.SettingsFrame.pas
+++ b/client/source/DelphiLint.SettingsFrame.pas
@@ -56,14 +56,14 @@ type
     GeneralSheet: TTabSheet;
     StandaloneSheet: TTabSheet;
     ConnectedSheet: TTabSheet;
-    Label3: TLabel;
+    AuthHeaderLabel: TLabel;
     Label4: TLabel;
     ConnectedPanel: TPanel;
     GeneralPanel: TPanel;
     StandalonePanel: TPanel;
     Label2: TLabel;
     VersionRefreshButton: TButton;
-    Panel2: TPanel;
+    ConnectedTopPanel: TPanel;
     Panel3: TPanel;
     Label5: TLabel;
     StandaloneRulesRadioGroup: TRadioGroup;
@@ -73,6 +73,9 @@ type
     EnableAll: TMenuItem;
     DisableAll: TMenuItem;
     PlaceholderStandaloneRulesPanel: TPanel;
+    TokenNoteLabel: TLabel;
+    TokenNotePanel: TPanel;
+    LearnMoreButton: TButton;
     procedure ComponentsButtonClick(Sender: TObject);
     procedure SonarDelphiVersionRadioGroupClick(Sender: TObject);
     procedure VersionRefreshButtonClick(Sender: TObject);
@@ -80,6 +83,7 @@ type
     procedure EnableAllClick(Sender: TObject);
     procedure DisableAllClick(Sender: TObject);
     procedure PlaceholderStandaloneRulesPanelClick(Sender: TObject);
+    procedure LearnMoreButtonClick(Sender: TObject);
   private
     FOnReleasesRetrieved: TThreadSafeEventNotifier<TArray<string>>;
     FReleasesRetrieved: Boolean;
@@ -120,6 +124,9 @@ uses
   , DelphiLint.SetupForm
   , DelphiLint.Context
   , DelphiLint.Settings
+  , DelphiLint.ExternalConsts
+  , Winapi.ShellAPI
+  , Winapi.Windows
   ;
 
 {$R *.dfm}
@@ -251,6 +258,16 @@ end;
 
 //______________________________________________________________________________________________________________________
 
+procedure TLintSettingsFrame.LearnMoreButtonClick(Sender: TObject);
+var
+  Url: string;
+begin
+  Url := DelphiLint.ExternalConsts.CTokenInfoUrl;
+  ShellExecute(0, 'open', PChar(Url), nil, nil, SW_SHOWNORMAL);
+end;
+
+//______________________________________________________________________________________________________________________
+
 procedure TLintSettingsFrame.PlaceholderStandaloneRulesPanelClick(Sender: TObject);
 begin
   if (StandaloneRulesRadioGroup.ItemIndex = 1) and not Assigned(FStandaloneRules) then begin
@@ -340,8 +357,6 @@ end;
 //______________________________________________________________________________________________________________________
 
 procedure TLintSettingsFrame.RetrieveReleases;
-const
-  CApiUrl = 'https://api.github.com/repos/integrated-application-development/sonar-delphi/releases';
 var
   Http: THTTPClient;
   Response: IHTTPResponse;
@@ -353,10 +368,12 @@ begin
   Http := THTTPClient.Create;
   try
     try
-      Response := Http.Get(CApiUrl);
+      Response := Http.Get(DelphiLint.ExternalConsts.CReleasesApiUrl);
     except
       on E: ENetHTTPClientException do begin
-        Log.Warn('Could not retrieve SonarDelphi releases from %s: %s', [CApiUrl, E.Message]);
+        Log.Warn(
+          'Could not retrieve SonarDelphi releases from %s: %s',
+          [DelphiLint.ExternalConsts.CReleasesApiUrl, E.Message]);
         FOnReleasesRetrieved.Notify([]);
         Exit;
       end;

--- a/client/source/DelphiLintClient280.dpk
+++ b/client/source/DelphiLintClient280.dpk
@@ -67,7 +67,8 @@ contains
   DelphiLint.ExtWebView2 in 'DelphiLint.ExtWebView2.pas',
   DelphiLint.LiveData in 'DelphiLint.LiveData.pas',
   DelphiLint.IssueActions in 'DelphiLint.IssueActions.pas',
-  DelphiLint.PopupHook in 'DelphiLint.PopupHook.pas';
+  DelphiLint.PopupHook in 'DelphiLint.PopupHook.pas',
+  DelphiLint.ExternalConsts in 'DelphiLint.ExternalConsts.pas';
 
 {$R DelphiLintClientAdditional.res}
 

--- a/client/source/DelphiLintClient280.dproj
+++ b/client/source/DelphiLintClient280.dproj
@@ -139,6 +139,7 @@ $(PreBuildEvent)]]>
         <DCCReference Include="DelphiLint.LiveData.pas"/>
         <DCCReference Include="DelphiLint.IssueActions.pas"/>
         <DCCReference Include="DelphiLint.PopupHook.pas"/>
+        <DCCReference Include="DelphiLint.ExternalConsts.pas"/>
         <RcItem Include="..\assets\delphilint_icon_24x24.bmp">
             <ResourceType>BITMAP</ResourceType>
             <ResourceId>DL_SPLASH</ResourceId>

--- a/client/source/DelphiLintClient290.dpk
+++ b/client/source/DelphiLintClient290.dpk
@@ -67,7 +67,8 @@ contains
   DelphiLint.ExtWebView2 in 'DelphiLint.ExtWebView2.pas',
   DelphiLint.LiveData in 'DelphiLint.LiveData.pas',
   DelphiLint.IssueActions in 'DelphiLint.IssueActions.pas',
-  DelphiLint.PopupHook in 'DelphiLint.PopupHook.pas';
+  DelphiLint.PopupHook in 'DelphiLint.PopupHook.pas',
+  DelphiLint.ExternalConsts in 'DelphiLint.ExternalConsts.pas';
 
 {$R DelphiLintClientAdditional.res}
 

--- a/client/source/DelphiLintClient290.dproj
+++ b/client/source/DelphiLintClient290.dproj
@@ -140,6 +140,7 @@ $(PreBuildEvent)]]>
         <DCCReference Include="DelphiLint.LiveData.pas"/>
         <DCCReference Include="DelphiLint.IssueActions.pas"/>
         <DCCReference Include="DelphiLint.PopupHook.pas"/>
+        <DCCReference Include="DelphiLint.ExternalConsts.pas"/>
         <RcItem Include="..\assets\delphilint_icon_24x24.bmp">
             <ResourceType>BITMAP</ResourceType>
             <ResourceId>DL_SPLASH</ResourceId>

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -3,6 +3,7 @@
 - [General](#general)
   - [How do I supply custom options to the Java Virtual Machine?](#how-do-i-supply-custom-options-to-the-java-virtual-machine)
   - [How do I uninstall DelphiLint?](#how-do-i-uninstall-delphilint)
+  - [How do I authenticate with a SonarQube instance in Connected Mode?](#how-do-i-authenticate-with-a-sonarqube-instance-in-connected-mode)
 - [Troubleshooting](#troubleshooting)
   - [When I go to analyze a file, it says "File not analyzable" and analysis is greyed out.](#when-i-go-to-analyze-a-file-it-says-file-not-analyzable-and-analysis-is-greyed-out)
   - ["Analyze All Open Files" does not analyze my `.dpr` or `.dpk` file, even though it is open.](#analyze-all-open-files-does-not-analyze-my-dpr-or-dpk-file-even-though-it-is-open)
@@ -35,6 +36,22 @@ To totally remove all traces of DelphiLint from your system, delete the folder `
 > [!NOTE]
 > When upgrading to a new DelphiLint version, the install script automatically uninstalls any other versions -
 > there is no need to perform a manual uninstall beforehand.
+
+### How do I authenticate with a SonarQube instance in Connected Mode?
+
+Unless "Force user authentication" is disabled on the SonarQube instance, you will require a SonarQube token.
+SonarQube allows you to generate three types of tokens:
+
+* User tokens, which authenticate as a certain user
+* Project analysis tokens, which can be used to run analyses on the project it was generated for
+* Global analysis tokens, which can be used to run analyses on every project
+
+While DelphiLint supports all three token types, it is highly recommended that you provide **user** tokens if possible.
+Due to an undocumented limitation in SonarQube's API, project analysis tokens and global analysis tokens are unable to
+access information about project security hotspots.
+
+For more information about generating and using tokens, see the
+[SonarQube documentation](https://docs.sonarsource.com/sonarqube/latest/user-guide/user-account/generating-and-using-tokens/).
 
 ## Troubleshooting
 

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/remote/SonarHostForbiddenException.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/remote/SonarHostForbiddenException.java
@@ -1,0 +1,24 @@
+/*
+ * DelphiLint Server
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package au.com.integradev.delphilint.remote;
+
+public class SonarHostForbiddenException extends SonarHostStatusCodeException {
+  public SonarHostForbiddenException() {
+    super(403);
+  }
+}

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/remote/sonarqube/HttpSonarApi.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/remote/sonarqube/HttpSonarApi.java
@@ -21,6 +21,7 @@ import au.com.integradev.delphilint.remote.JsonHttpHandler;
 import au.com.integradev.delphilint.remote.SonarHostBadRequestException;
 import au.com.integradev.delphilint.remote.SonarHostConnectException;
 import au.com.integradev.delphilint.remote.SonarHostException;
+import au.com.integradev.delphilint.remote.SonarHostForbiddenException;
 import au.com.integradev.delphilint.remote.SonarHostStatusCodeException;
 import au.com.integradev.delphilint.remote.SonarHostUnauthorizedException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -123,6 +124,8 @@ public class HttpSonarApi implements SonarApi {
         throw new SonarHostBadRequestException();
       } else if (response.statusCode() == 401) {
         throw new SonarHostUnauthorizedException();
+      } else if (response.statusCode() == 403) {
+        throw new SonarHostForbiddenException();
       } else {
         throw new SonarHostStatusCodeException(response.statusCode());
       }


### PR DESCRIPTION
SonarDelphi currently fails with an error when trying to use a project analysis or global analysis token, caused by an undocumented and likely incorrect behaviour of the SonarQube API (security hotspots cannot be retrieved by these tokens).

This PR alters issue retrieval to swallow 403 exceptions when accessing `/api/hotspots/search`, fixing this issue and allowing these tokens to be used. It also updates supplementary documentation to explain this, and recommend the use of user tokens if at all possible.

In addition, I've adjusted the validation behaviour for the Project Options window to disable the Save button if the project key or URL is blank, mitigating the need for #58 in the short term.

Fixes #59, possibly helps with #53