### PR TITLE
Bump SonarDelphi default version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Project Options now prevents a blank server URL or project key when in Connected Mode.
+* The default SonarDelphi version is now [1.8.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.8.0).
 
 ### Fixed
 

--- a/client/source/DelphiLint.Settings.pas
+++ b/client/source/DelphiLint.Settings.pas
@@ -175,7 +175,7 @@ end;
 
 function TLintSettings.GetDefaultSonarDelphiVersion: string;
 begin
-  Result := '1.6.0';
+  Result := '1.8.0';
 end;
 
 //______________________________________________________________________________________________________________________

--- a/companion/delphilint-vscode/src/settings.ts
+++ b/companion/delphilint-vscode/src/settings.ts
@@ -129,7 +129,7 @@ export function getSonarDelphiVersion(): string {
   if (override) {
     return override;
   } else {
-    return "1.6.0";
+    return "1.8.0";
   }
 }
 


### PR DESCRIPTION
This PR updates the default SonarDelphi version to 1.8.0. Release notes can be seen [here](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.8.0).