### PR TITLE
Remove unnecessary parentheses in DelphiLint.Server

### DIFF
--- a/client/source/DelphiLint.Server.pas
+++ b/client/source/DelphiLint.Server.pas
@@ -925,7 +925,7 @@ begin
     while not Terminated do begin
       AcquireServerPossibleUninit;
       try
-        if Assigned(FServer) and (not Terminated) and not (FServer.Process) then begin
+        if Assigned(FServer) and (not Terminated) and not FServer.Process then begin
           FServer := nil;
           Break;
         end;


### PR DESCRIPTION
Fixes a Sonar issue in Delphi code, raised by improvements to `RedundantParentheses` in SonarDelphi 1.10.0.