### PR TITLE
Check `JAVA_HOME` is valid in `SetupForm` when clearing

### DIFF
--- a/client/source/DelphiLint.SetupForm.pas
+++ b/client/source/DelphiLint.SetupForm.pas
@@ -236,6 +236,7 @@ begin
   ServerJarIndicator.Caption := LintContext.Settings.ServerJar;
   UpdateValidState(JavaExeIndicator, IsValidValue(GetEffectiveJavaExe));
   UpdateValidState(ServerJarIndicator, IsValidValue(LintContext.Settings.ServerJar));
+  UpdateOkButton;
 end;
 
 //______________________________________________________________________________________________________________________
@@ -257,8 +258,6 @@ begin
     Indicator.Color := clMaroon;
     Indicator.Font.Color := clWhite;
   end;
-
-  UpdateOkButton;
 end;
 
 //______________________________________________________________________________________________________________________

--- a/client/source/DelphiLint.SetupForm.pas
+++ b/client/source/DelphiLint.SetupForm.pas
@@ -221,6 +221,8 @@ begin
   FJavaExeOverride := '';
   JavaExeIndicator.Caption := GetJavaExeCaption;
   JavaExeClearButton.Enabled := False;
+  UpdateValidState(JavaExeIndicator, IsValidValue(GetEffectiveJavaExe));
+  UpdateOkButton;
 end;
 
 //______________________________________________________________________________________________________________________


### PR DESCRIPTION
`JAVA_HOME` path set can be incorrect which cause the setup form to open. Validation could be bypassed by selecting correct Java path then clear