### PR TITLE
Bump SonarDelphi default version to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Project Options now prevents a blank server URL or project key when in Connected Mode.
-* The default SonarDelphi version is now [1.8.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.8.0).
+* The default SonarDelphi version is now [1.10.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.10.0).
 
 ### Fixed
 

--- a/client/source/DelphiLint.Settings.pas
+++ b/client/source/DelphiLint.Settings.pas
@@ -175,7 +175,7 @@ end;
 
 function TLintSettings.GetDefaultSonarDelphiVersion: string;
 begin
-  Result := '1.8.0';
+  Result := '1.10.0';
 end;
 
 //______________________________________________________________________________________________________________________

--- a/companion/delphilint-vscode/src/settings.ts
+++ b/companion/delphilint-vscode/src/settings.ts
@@ -129,7 +129,7 @@ export function getSonarDelphiVersion(): string {
   if (override) {
     return override;
   } else {
-    return "1.8.0";
+    return "1.10.0";
   }
 }
 


### PR DESCRIPTION
This bumps the default SonarDelphi version to the latest available. See release notes: [v1.10.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.10.0)

This is in anticipation of a new minor DelphiLint release.