### PR TITLE
Support wildcard project keys in token settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Support for wildcard project keys when configuring authorization tokens.
+
 ### Changed
 
 * Project Options now prevents a blank server URL or project key when in Connected Mode.

--- a/client/source/DelphiLint.Settings.pas
+++ b/client/source/DelphiLint.Settings.pas
@@ -292,6 +292,12 @@ begin
   Result := '';
   if FTokensMap.ContainsKey(Key) then begin
     Result := FTokensMap[Key];
+  end
+  else begin
+    Key.ProjectKey := '*';
+    if FTokensMap.ContainsKey(Key) then begin
+      Result := FTokensMap[Key];
+    end;
   end;
 end;
 

--- a/client/test/DelphiLintTest.Settings.pas
+++ b/client/test/DelphiLintTest.Settings.pas
@@ -61,6 +61,8 @@ type
     [Test]
     procedure TestSonarHostTokensMigrationPath;
     [Test]
+    procedure TestSonarHostTokensWildcard;
+    [Test]
     procedure TestDisabledRules;
     [Test]
     procedure TestServerJvmOptions;
@@ -391,6 +393,38 @@ begin
       'project2@https://sonar.foo.bar=token2,' +
       'project3@https://foo.sonar.baz=token3',
     GetSetting(CCategory, CName + '_0'));
+end;
+
+//______________________________________________________________________________________________________________________
+
+procedure TSettingsTest.TestSonarHostTokensWildcard;
+const
+  CCategory = 'SonarHost';
+  CName = 'Tokens';
+begin
+  SetSetting(CCategory, CName + '_Size', '1');
+  SetSetting(
+    CCategory,
+    CName + '_0',
+    'project1@https://sonar.example.com=token1,'
+    + '*@https://sonar.foo.bar=token2,'
+    + 'project3@https://sonar.foo.bar=token3,'
+    + 'project4@https://sonar.foo.bar=');
+
+  FSettings.Load;
+  Assert.AreEqual(4, FSettings.SonarHostTokensMap.Count);
+  Assert.AreEqual(
+    'token1',
+    FSettings.GetSonarHostToken('https://sonar.example.com', 'project1'));
+  Assert.AreEqual(
+    'token2',
+    FSettings.GetSonarHostToken('https://sonar.foo.bar', 'any project name'));
+  Assert.AreEqual(
+    'token3',
+    FSettings.GetSonarHostToken('https://sonar.foo.bar', 'project3'));
+  Assert.AreEqual(
+    '',
+    FSettings.GetSonarHostToken('https://sonar.foo.bar', 'project4'));
 end;
 
 //______________________________________________________________________________________________________________________

--- a/companion/delphilint-vscode/src/command.ts
+++ b/companion/delphilint-vscode/src/command.ts
@@ -147,10 +147,15 @@ async function retrieveEffectiveConfiguration(
       config.sonarHostUrl = projectOptions.sonarHostUrl();
       config.projectKey = projectOptions.projectKey();
       console.log(settings.getSonarTokens());
+
+      let sonarTokens = settings.getSonarTokens();
+
       config.apiToken =
-        settings.getSonarTokens()?.[projectOptions.sonarHostUrl()]?.[
+        sonarTokens[projectOptions.sonarHostUrl()]?.[
           projectOptions.projectKey()
-        ] ?? "";
+        ] ??
+        sonarTokens[projectOptions.sonarHostUrl()]?.["*"] ??
+        "";
     }
   } else {
     config.baseDir = path.dirname(projectFile);


### PR DESCRIPTION
Adds support for a wildcard project key when configuring authorization tokens in DelphiLint settings. When scanning a project, if there is no authorization token listed under the project key and host combination, it will then attempt to find an authorization token listed under `*` and the host. 

Example of a wildcard project key:

![image](https://github.com/user-attachments/assets/b334680f-35d3-4210-a115-c2ad3b93d5eb)

See discussion in https://github.com/integrated-application-development/delphilint/issues/53#issuecomment-2272483229