### PR TITLE
Fix assorted Sonar issues

### DIFF
--- a/companion/delphilint-vscode/src/command.ts
+++ b/companion/delphilint-vscode/src/command.ts
@@ -148,7 +148,7 @@ async function retrieveEffectiveConfiguration(
       config.projectKey = projectOptions.projectKey();
       console.log(settings.getSonarTokens());
 
-      let sonarTokens = settings.getSonarTokens();
+      const sonarTokens = settings.getSonarTokens();
 
       config.apiToken =
         sonarTokens[projectOptions.sonarHostUrl()]?.[

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -183,7 +183,7 @@ function Invoke-VscCompanionCompile {
   Push-Location (Join-Path $PSScriptRoot ..\companion\delphilint-vscode)
   try {
     & npm install
-    & npx @vscode/vsce package --skip-license
+    & npx -y @vscode/vsce package --skip-license
   }
   finally {
     Pop-Location

--- a/server/delphilint-server/src/main/java/au/com/integradev/delphilint/server/AnalysisServer.java
+++ b/server/delphilint-server/src/main/java/au/com/integradev/delphilint/server/AnalysisServer.java
@@ -121,8 +121,7 @@ public class AnalysisServer {
               sonarHost,
               properties);
 
-      ResponseAnalyzeResult result =
-          ResponseAnalyzeResult.fromIssueSet(issues, logOutput.getMessages());
+      var result = ResponseAnalyzeResult.fromIssueSet(issues, logOutput.getMessages());
       result.convertPathsToAbsolute(requestAnalyze.getBaseDir());
       sendMessage.accept(LintMessage.analyzeResult(result));
     } catch (SonarHostUnauthorizedException e) {


### PR DESCRIPTION
This PR fixes some Sonar issues raised by recent work #67 and #69. It also fixes (as a separate commit) a minor issue I noticed in the `build.ps1` script - the `vsce package` command used to build the VS Code companion hangs forever with an invisible prompt if `@vscode/vsce` is not installed.