### PR TITLE
Fix intermittent webview issues on IDE startup when DelphiLint window layout is saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Intermittent embedded browser error on IDE startup with certain system configurations.
+
 ## [1.2.0] - 2024-10-14
 
 ### Added

--- a/client/source/DelphiLint.IDEContext.pas
+++ b/client/source/DelphiLint.IDEContext.pas
@@ -271,7 +271,6 @@ begin
   FSettingsDir := TPath.Combine(TPath.GetHomePath, 'DelphiLint');
   FSettings := TLintSettings.Create(TPath.Combine(FSettingsDir, 'delphilint.ini'));
 
-  Log.Info('-------------------------------------------------');
   Log.Info('DelphiLint started at %s', [DateToISO8601(Now)]);
 end;
 

--- a/client/source/DelphiLint.Settings.pas
+++ b/client/source/DelphiLint.Settings.pas
@@ -215,7 +215,6 @@ var
 begin
   FTokensMap.Clear;
 
-  Log.Info(SonarHostTokens);
   HostTokenPairs := SplitString(SonarHostTokens, ',');
   for Pair in HostTokenPairs do begin
     SplitPair := SplitString(Pair, '=');

--- a/client/source/DelphiLint.SettingsFrame.pas
+++ b/client/source/DelphiLint.SettingsFrame.pas
@@ -240,11 +240,10 @@ begin
   FOnReleasesRetrieved := TThreadSafeEventNotifier<TArray<string>>.Create;
   FOnReleasesRetrieved.AddListener(
     procedure(const Releases: TArray<string>) begin
-      Log.Info('%d releases retrieved', [Length(Releases)]);
       TThread.Synchronize(
         TThread.Current,
         procedure begin
-          Log.Info('%d releases retrieved (sync)', [Length(Releases)]);
+          Log.Info('%d releases retrieved', [Length(Releases)]);
           PopulateSonarDelphiVersionConfig(Releases);
         end);
     end);

--- a/client/source/DelphiLint.ToolFrame.dfm
+++ b/client/source/DelphiLint.ToolFrame.dfm
@@ -618,4 +618,10 @@ object LintToolFrame: TLintToolFrame
       FE7FFE7FFE7FFE7FFE7FFE7FFE7FFE7F00000000000000000000000000000000
       000000000000}
   end
+  object WebViewInitTimer: TTimer
+    Interval = 100
+    OnTimer = WebViewInitTimerTimer
+    Left = 504
+    Top = 16
+  end
 end

--- a/client/source/DelphiLint.ToolFrame.pas
+++ b/client/source/DelphiLint.ToolFrame.pas
@@ -791,9 +791,6 @@ begin
     Color.B := GetBValue(DelphiColor);
     Color.A := 255;
     Controller2.Put_DefaultBackgroundColor(Color);
-
-    Controller2.Get_DefaultBackgroundColor(Color);
-    Log.Info('Default background is now rgba(%d, %d, %d, %d)', [Color.R, Color.G, Color.B, Color.A]);
   end;
 end;
 


### PR DESCRIPTION
This PR adjusts the Edge embed refresh logic to batch together all refresh requests within 100ms of each other. This may help resolve intermittent false positive errors that have been observed on IDE startup when the window layout includes the DelphiLint panel.

I also took the opportunity to tidy up some unhelpful log messages that I've found unnecessarily noisy when debugging. 