### PR TITLE
Update highlight.js to 11.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Highlight.js has been updated to 11.10.0, improving rule description syntax highlighting for numeric literals
+  and character strings.
+
 ### Fixed
 
 * Intermittent embedded browser error on IDE startup with certain system configurations.

--- a/client/jslib/package.json
+++ b/client/jslib/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "core-js": "^3.34.0",
     "diff": "^5.1.0",
-    "highlight.js": "^11.9.0"
+    "highlight.js": "^11.10.0"
   }
 }


### PR DESCRIPTION
This PR updates the version of highlight.js bundled with DelphiLint to 11.10.0. This contains a number of improvements to the Delphi highlighter:

> * enh(delphi) allow digits to be omitted for hex and binary literals [Jonah Jeleniewski](https://github.com/cirras)
> * enh(delphi) add support for digit separators [Jonah Jeleniewski](https://github.com/cirras)
> * enh(delphi) add support for character strings with non-decimal numerics [Jonah Jeleniewski](https://github.com/cirras)

Thanks [Jonah Jeleniewski](https://github.com/cirras)!