### PR TITLE
Bump SonarDelphi default version to 1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Highlight.js has been updated to 11.10.0, improving rule description syntax highlighting for numeric literals
   and character strings.
+* The default SonarDelphi version is now [1.12.1](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.12.1).
 
 ### Fixed
 

--- a/client/source/DelphiLint.Settings.pas
+++ b/client/source/DelphiLint.Settings.pas
@@ -175,7 +175,7 @@ end;
 
 function TLintSettings.GetDefaultSonarDelphiVersion: string;
 begin
-  Result := '1.10.0';
+  Result := '1.12.1';
 end;
 
 //______________________________________________________________________________________________________________________

--- a/companion/delphilint-vscode/src/settings.ts
+++ b/companion/delphilint-vscode/src/settings.ts
@@ -129,7 +129,7 @@ export function getSonarDelphiVersion(): string {
   if (override) {
     return override;
   } else {
-    return "1.10.0";
+    return "1.12.1";
   }
 }
 


### PR DESCRIPTION
This PR bumps the default version of SonarDelphi from 1.10.0 to 1.12.1:

- [1.11.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.11.0)
- [1.12.0](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.12.0)
- [1.12.1](https://github.com/integrated-application-development/sonar-delphi/releases/tag/v1.12.1)