### PR TITLE
Fix various bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Intermittent embedded browser error on IDE startup with certain system configurations.
+* Blank rule view in certain situations after docking or undocking the DelphiLint window.
+* Unhandled exception when retrieval of rules from a remote SonarQube server fails.
+* Plugin information in Help > About persisting after the plugin is disabled.
 
 ## [1.2.0] - 2024-10-14
 

--- a/client/source/DelphiLint.Plugin.pas
+++ b/client/source/DelphiLint.Plugin.pas
@@ -432,7 +432,7 @@ begin
     'Code analyzer powered by SonarDelphi',
     VersionStr);
 
-  IDEServices.AddPluginInfo(
+  FInfoIndex := IDEServices.AddPluginInfo(
     'DelphiLint ' + VersionStr,
     'Free and open source Delphi code linter, powered by the SonarDelphi code analysis tool for SonarQube.'
     + #13#10#13#10'Copyright © 2023 Integrated Application Development',

--- a/client/source/DelphiLint.ToolFrame.dfm
+++ b/client/source/DelphiLint.ToolFrame.dfm
@@ -619,7 +619,7 @@ object LintToolFrame: TLintToolFrame
       000000000000}
   end
   object WebViewInitTimer: TTimer
-    Interval = 100
+    Interval = 200
     OnTimer = WebViewInitTimerTimer
     Left = 504
     Top = 16


### PR DESCRIPTION
This PR fixes three bugs:

* Plugin information (Help > About Embarcadero Delphi) is currently not cleaned up when the plugin is deactivated
* The embedded Edge browser that shows the rule view can be rendered as blank in certain situations when docking or undocking the DelphiLint window
* An access violation currently occurs when there is an error retrieving rule descriptions from the SonarQube server