### PR TITLE
Fix failing format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: maven
       - uses: axel-op/googlejavaformat-action@v3
+        name: Format
         with:
           args: "--set-exit-if-changed --dry-run"


### PR DESCRIPTION
This PR updates the Java version the format workflow is running to Java 17. As of [1.25.0](https://github.com/google/google-java-format/releases/tag/v1.25.0), google-java-format requires Java 17+ to build.