### PR TITLE
Fix incorrect .dproj detection when another .dproj file is included as a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Blank rule view in certain situations after docking or undocking the DelphiLint window.
 * Unhandled exception when retrieval of rules from a remote SonarQube server fails.
 * Plugin information in Help > About persisting after the plugin is disabled.
+* Incorrect detection of project file (.dproj) when another .dproj file is included as a resource.
 
 ## [1.2.0] - 2024-10-14
 

--- a/client/source/DelphiLint.Context.pas
+++ b/client/source/DelphiLint.Context.pas
@@ -90,7 +90,10 @@ type
   IIDEProject = interface
     ['{323288E1-A17D-441D-8BA7-5C4290C6F6FD}']
     procedure GetCompleteFileList(FileList: TStrings);
+    function GetFileName: string;
     function Raw: IInterface; // IOTAProject
+
+    property FileName: string read GetFileName;
   end;
 
   IIDEModule = interface;

--- a/client/source/DelphiLint.IDEContext.pas
+++ b/client/source/DelphiLint.IDEContext.pas
@@ -183,6 +183,7 @@ type
 
   TToolsApiProject = class(TToolsApiWrapper<IOTAProject>, IIDEProject)
   public
+    function GetFileName: string;
     procedure GetCompleteFileList(FileList: TStrings);
   end;
 
@@ -756,6 +757,13 @@ end;
 procedure TToolsApiProject.GetCompleteFileList(FileList: TStrings);
 begin
   FRaw.GetCompleteFileList(FileList);
+end;
+
+//______________________________________________________________________________________________________________________
+
+function TToolsApiProject.GetFileName: string;
+begin
+  Result := FRaw.FileName;
 end;
 
 //______________________________________________________________________________________________________________________

--- a/client/test/DelphiLintTest.MockContext.pas
+++ b/client/test/DelphiLintTest.MockContext.pas
@@ -170,12 +170,15 @@ type
   TMockProject = class(TMockIDEObject, IIDEProject)
   private
     FFileList: TList<string>;
+    FFileName: string;
   public
     constructor Create;
     destructor Destroy; override;
 
+    function GetFileName: string;
     procedure GetCompleteFileList(FileList: TStrings);
     property MockedFileList: TList<string> read FFileList write FFileList;
+    property FileName: string read GetFileName write FFileName;
   end;
 
   TModuleCallType = (mdcSave);
@@ -1347,6 +1350,11 @@ begin
   for FileName in FFileList do begin
     FileList.Add(FileName);
   end;
+end;
+
+function TMockProject.GetFileName: string;
+begin
+  Result := FFileName;
 end;
 
 //______________________________________________________________________________________________________________________

--- a/client/test/DelphiLintTest.Utils.pas
+++ b/client/test/DelphiLintTest.Utils.pas
@@ -157,9 +157,11 @@ begin
 
   MockedFiles := TList<string>.Create;
   Project.MockedFileList := MockedFiles;
+  Project.FileName := 'myproject.dproj';
   MockedFiles.Add('abc.pas');
   MockedFiles.Add('def.dfm');
   MockedFiles.Add('ghi.dpk');
+  MockedFiles.Add('myproject.dproj');
   MockedFiles.Add('jkl.dpr');
   MockedFiles.Add('mno.dproj');
   MockedFiles.Add('pqr.txt');
@@ -169,8 +171,8 @@ begin
   Assert.AreEqual(4, Length(AllFiles));
   Assert.AreEqual('abc.pas', AllFiles[0]);
   Assert.AreEqual('ghi.dpk', AllFiles[1]);
-  Assert.AreEqual('jkl.dpr', AllFiles[2]);
-  Assert.AreEqual('mno.dproj', AllFiles[3]);
+  Assert.AreEqual('myproject.dproj', AllFiles[2]);
+  Assert.AreEqual('jkl.dpr', AllFiles[3]);
 end;
 
 //______________________________________________________________________________________________________________________
@@ -342,9 +344,7 @@ begin
 
   Project := TMockProject.Create;
   IDEServices.MockActiveProject(Project);
-
-  Project.MockedFileList := TList<string>.Create;
-  Project.MockedFileList.Add('C:\abc\def\ghi.dproj');
+  Project.FileName := 'C:\abc\def\ghi.dproj';
 
   Assert.IsTrue(TryGetProjectDirectory(ProjectDir, False));
   Assert.AreEqual('C:\abc\def', ProjectDir);
@@ -374,9 +374,7 @@ begin
 
   Project := TMockProject.Create;
   IDEServices.MockActiveProject(Project);
-
-  Project.MockedFileList := TList<string>.Create;
-  Project.MockedFileList.Add(CProjectFile);
+  Project.FileName := CProjectFile;
 
   Assert.IsTrue(TryGetProjectDirectory(ProjectDir, True));
   Assert.AreEqual(CProjectDir, ProjectDir);
@@ -405,6 +403,7 @@ begin
 
   Project := TMockProject.Create;
   IDEServices.MockActiveProject(Project);
+  Project.FileName := 'stu.dproj';
 
   Project.MockedFileList := TList<string>.Create;
   Project.MockedFileList.Add('abc.pas');
@@ -413,9 +412,10 @@ begin
   Project.MockedFileList.Add('jkl.dpr');
   Project.MockedFileList.Add('mno.dproj');
   Project.MockedFileList.Add('pqr.txt');
+  Project.MockedFileList.Add('stu.dproj');
 
   Assert.IsTrue(TryGetProjectFile(ProjectFile));
-  Assert.AreEqual('mno.dproj', ProjectFile);
+  Assert.AreEqual('stu.dproj', ProjectFile);
 end;
 
 //______________________________________________________________________________________________________________________


### PR DESCRIPTION
This PR fixes a bug in which a resource with a `.dproj` extension may be incorrectly identified as the project file for the project. This was due to a naive implementation of retrieving the project file name that iterated over all files in the project - this is unnecessary as the ToolsAPI has a `FileName` property that contains all we need.