### PR TITLE
Remove redundant `Exit`

### DIFF
--- a/client/source/DelphiLint.Plugin.pas
+++ b/client/source/DelphiLint.Plugin.pas
@@ -162,7 +162,6 @@ begin
       SourceEditor.Module.Save(True);
     end;
     Analyzer.AnalyzeFiles([SourceEditor.FileName, ProjectFile], ProjectFile);
-    Exit;
   end;
 end;
 


### PR DESCRIPTION
This PR removes a redundant `Exit` in `TPluginCore.ActionAnalyzeActiveFileExecute`.