### PR TITLE
Add clear all issues command

### DIFF
--- a/companion/delphilint-vscode/package.json
+++ b/companion/delphilint-vscode/package.json
@@ -46,6 +46,10 @@
       {
         "command": "delphilint-vscode.clearThisFile",
         "title": "DelphiLint: Clear Issues For This File"
+      },
+      {
+        "command": "delphilint-vscode.clearAllIssues",
+        "title": "DelphiLint: Clear All Issues"
       }
     ],
     "configuration": {

--- a/companion/delphilint-vscode/src/command.ts
+++ b/companion/delphilint-vscode/src/command.ts
@@ -339,3 +339,9 @@ export async function clearThisFile(
     issueCollection.set(activeTextEditor.document.uri, undefined);
   }
 }
+
+export async function clearAllIssues(
+  issueCollection: vscode.DiagnosticCollection
+) {
+  issueCollection.clear();
+}

--- a/companion/delphilint-vscode/src/extension.ts
+++ b/companion/delphilint-vscode/src/extension.ts
@@ -21,6 +21,7 @@ import {
   analyzeAllOpenFiles,
   analyzeThisFile,
   chooseActiveProject,
+  clearAllIssues,
   clearThisFile,
 } from "./command";
 import { getStatusItem } from "./display";
@@ -85,6 +86,12 @@ export function activate(context: vscode.ExtensionContext) {
     () => clearThisFile(lintIssueCollection)
   );
   context.subscriptions.push(clearThisFileCommand);
+
+  const clearAllIssuesCommand = vscode.commands.registerCommand(
+    "delphilint-vscode.clearAllIssues",
+    () => clearAllIssues(lintIssueCollection)
+  );
+  context.subscriptions.push(clearAllIssuesCommand);
 
   const chooseActiveProjectCommand = vscode.commands.registerCommand(
     "delphilint-vscode.chooseActiveProject",


### PR DESCRIPTION
## Description of the change

Add a "Clear All Issues" command that removes issues from all files

## Rationale for the change / use case

When fixing issues and also write other code, the Sonar warning lingers even after removed. It's very distracting and clutter the problem count in the file. It will be nice to remove issues temporarily before rescanning

## Why the change is broadly useful

Clear Sonar issues without reloading VS Code

## Reasoning behind any design and implementation decisions?

Pretty straight forward